### PR TITLE
Add updated_at trigger to all models

### DIFF
--- a/migrations/20250222030514_add_modified_at_trigger.sql
+++ b/migrations/20250222030514_add_modified_at_trigger.sql
@@ -1,0 +1,48 @@
+    -- +goose Up
+    -- +goose StatementBegin
+    SELECT 'up SQL query';
+    CREATE OR REPLACE FUNCTION update_modified_at_column()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        NEW.modified_at = CURRENT_TIMESTAMP;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    CREATE TRIGGER set_modified_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_at_column();
+
+    CREATE TRIGGER set_modified_at
+    BEFORE UPDATE ON repetitive_task_templates
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_at_column();
+
+    CREATE TRIGGER set_modified_at
+    BEFORE UPDATE ON tasks
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_at_column();
+
+    CREATE TRIGGER set_modified_at
+    BEFORE UPDATE ON tags
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_at_column();
+
+    CREATE TRIGGER set_modified_at
+    BEFORE UPDATE ON spaces
+    FOR EACH ROW
+    EXECUTE FUNCTION update_modified_at_column();
+
+    -- +goose StatementEnd
+
+    -- +goose Down
+    -- +goose StatementBegin
+    SELECT 'down SQL query';
+    DROP TRIGGER IF EXISTS set_modified_at ON users;
+    DROP TRIGGER IF EXISTS set_modified_at ON repetitive_task_templates;
+    DROP TRIGGER IF EXISTS set_modified_at ON tasks;
+    DROP TRIGGER IF EXISTS set_modified_at ON tags;
+    DROP TRIGGER IF EXISTS set_modified_at ON spaces;
+
+    -- +goose StatementEnd

--- a/models/space.go
+++ b/models/space.go
@@ -12,7 +12,7 @@ type Space struct {
 	Name            string                   `gorm:"unique;not null" json:"name"`
 	Tasks           []Task                   `json:"tasks"`
 	RepetitiveTasks []RepetitiveTaskTemplate `json:"repetitiveTasks"`
-	CreatedAt       time.Time                `gorm:"autoCreateTime" json:"createdAt"`
+	CreatedAt       time.Time                `gorm:"type:timestamp" json:"createdAt"`
 	ModifiedAt      time.Time                `gorm:"type:timestamp" json:"modifiedAt"`
 	DeletedAt       gorm.DeletedAt           `gorm:"index" json:"-"`
 }

--- a/models/space.go
+++ b/models/space.go
@@ -13,6 +13,6 @@ type Space struct {
 	Tasks           []Task                   `json:"tasks"`
 	RepetitiveTasks []RepetitiveTaskTemplate `json:"repetitiveTasks"`
 	CreatedAt       time.Time                `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt      time.Time                `gorm:"autoUpdateTime" json:"modifiedAt"`
+	ModifiedAt      time.Time                `gorm:"type:timestamp" json:"modifiedAt"`
 	DeletedAt       gorm.DeletedAt           `gorm:"index" json:"-"`
 }

--- a/models/tag.go
+++ b/models/tag.go
@@ -13,6 +13,6 @@ type Tag struct {
 	Tasks           []Task                   `gorm:"many2many:task_tags" json:"tasks"`
 	RepetitiveTasks []RepetitiveTaskTemplate `gorm:"many2many:repetitive_task_template_tags" json:"repetitiveTasks"`
 	CreatedAt       time.Time                `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt      time.Time                `gorm:"autoUpdateTime" json:"modifiedAt"`
+	ModifiedAt      time.Time                `gorm:"type:timestamp" json:"modifiedAt"`
 	DeletedAt       gorm.DeletedAt           `gorm:"index" json:"-"`
 }

--- a/models/tag.go
+++ b/models/tag.go
@@ -12,7 +12,7 @@ type Tag struct {
 	Name            string                   `gorm:"not null" json:"name"`
 	Tasks           []Task                   `gorm:"many2many:task_tags" json:"tasks"`
 	RepetitiveTasks []RepetitiveTaskTemplate `gorm:"many2many:repetitive_task_template_tags" json:"repetitiveTasks"`
-	CreatedAt       time.Time                `gorm:"autoCreateTime" json:"createdAt"`
+	CreatedAt       time.Time                `gorm:"type:timestamp" json:"createdAt"`
 	ModifiedAt      time.Time                `gorm:"type:timestamp" json:"modifiedAt"`
 	DeletedAt       gorm.DeletedAt           `gorm:"index" json:"-"`
 }

--- a/models/task.go
+++ b/models/task.go
@@ -22,7 +22,7 @@ type Task struct {
 	RepetitiveTaskTemplate   *RepetitiveTaskTemplate `json:"repetitiveTaskTemplate"`
 	RepetitiveTaskTemplateId int                     `json:"repetitiveTaskTemplateId"`
 	CreatedAt                time.Time               `json:"createdAt"`
-	ModifiedAt               time.Time               `json:"modifiedAt"`
+	ModifiedAt               time.Time               `gorm:"type:timestamp" json:"modifiedAt"`
 	Tags                     []Tag                   `json:"tags"`
 	Space                    *Space                  `json:"space"`
 	SpaceId                  int                     `json:"spaceId"`
@@ -47,7 +47,7 @@ type RepetitiveTaskTemplate struct {
 	TimeOfDay                *string        `json:"timeOfDay"`
 	LastDateOfTaskGeneration *time.Time     `json:"lastDateOfTaskGeneration"`
 	CreatedAt                time.Time      `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt               time.Time      `gorm:"autoUpdateTime" json:"modifiedAt"`
+	ModifiedAt               time.Time      `gorm:"type:timestamp" json:"modifiedAt"`
 	Tags                     []Tag          `gorm:"many2many:repetitive_task_template_tags" json:"tags"`
 	Tasks                    []Task         `json:"tasks"`
 	Space                    *Space         `json:"space"`

--- a/models/task.go
+++ b/models/task.go
@@ -21,7 +21,7 @@ type Task struct {
 	TimeOfDay                *string                 `json:"timeOfDay"`
 	RepetitiveTaskTemplate   *RepetitiveTaskTemplate `json:"repetitiveTaskTemplate"`
 	RepetitiveTaskTemplateId int                     `json:"repetitiveTaskTemplateId"`
-	CreatedAt                time.Time               `json:"createdAt"`
+	CreatedAt                time.Time               `gorm:"type:timestamp" json:"createdAt"`
 	ModifiedAt               time.Time               `gorm:"type:timestamp" json:"modifiedAt"`
 	Tags                     []Tag                   `json:"tags"`
 	Space                    *Space                  `json:"space"`
@@ -45,8 +45,8 @@ type RepetitiveTaskTemplate struct {
 	Saturday                 *bool          `gorm:"default:false" json:"saturday"`
 	Sunday                   *bool          `gorm:"default:false" json:"sunday"`
 	TimeOfDay                *string        `json:"timeOfDay"`
-	LastDateOfTaskGeneration *time.Time     `json:"lastDateOfTaskGeneration"`
-	CreatedAt                time.Time      `gorm:"autoCreateTime" json:"createdAt"`
+	LastDateOfTaskGeneration *time.Time     `gorm:"type:timestamp" json:"lastDateOfTaskGeneration"`
+	CreatedAt                time.Time      `gorm:"type:timestamp" json:"createdAt"`
 	ModifiedAt               time.Time      `gorm:"type:timestamp" json:"modifiedAt"`
 	Tags                     []Tag          `gorm:"many2many:repetitive_task_template_tags" json:"tags"`
 	Tasks                    []Task         `json:"tasks"`

--- a/models/user.go
+++ b/models/user.go
@@ -13,6 +13,6 @@ type User struct {
 	Password   string         `gorm:"not null" json:"-"` // Excluded from JSON responses
 	Provider   string         `json:"provider"`
 	CreatedAt  time.Time      `json:"createdAt"`
-	ModifiedAt time.Time      `json:"modifiedAt"`
-	DeletedAt  gorm.DeletedAt `gorm:"index" json:"deletedAt"`
+	ModifiedAt time.Time      `gorm:"type:timestamp" json:"modifiedAt"`
+	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -12,7 +12,7 @@ type User struct {
 	Email      string         `gorm:"not null;unique" json:"email"`
 	Password   string         `gorm:"not null" json:"-"` // Excluded from JSON responses
 	Provider   string         `json:"provider"`
-	CreatedAt  time.Time      `json:"createdAt"`
+	CreatedAt  time.Time      `gorm:"type:timestamp" json:"createdAt"`
 	ModifiedAt time.Time      `gorm:"type:timestamp" json:"modifiedAt"`
 	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
 }


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces a database trigger to automatically update the `modified_at` column in several tables whenever a row is updated. It also updates the type of the `CreatedAt` and `ModifiedAt` fields in the corresponding models to `timestamp`.

Enhancements:
- Add a database trigger to automatically update the `modified_at` column on updates to the `users`, `repetitive_task_templates`, `tasks`, `tags`, and `spaces` tables.

Build:
- Update the type of the `CreatedAt` and `ModifiedAt` fields in the `Task`, `RepetitiveTaskTemplate`, `User`, `Space`, and `Tag` models to `timestamp`.