### PR TITLE
feat(signin): add refresh token to cache at the time of sign in

### DIFF
--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -144,6 +144,11 @@ func (h *AuthHandler) EmailSignIn(c *gin.Context) {
 		return
 	}
 
+	if err := h.tokenRepo.StoreAccessTokenAndRefreshToken(accessToken, refreshToken); err != nil {
+		h.respondWithError(c, http.StatusInternalServerError, apperrors.ErrRedisSet.LogError(), err, messages.ErrInternalServerError)
+		return
+	}
+
 	c.JSON(http.StatusOK,
 		utils.CreateJSONResponse(messages.Success, messages.MsgSignInSuccessful, gin.H{
 			"accessToken":  accessToken,


### PR DESCRIPTION
## Summary by Sourcery

Adds functionality to store access and refresh tokens in Redis upon user sign-in. This allows for efficient retrieval and management of tokens, improving the authentication process.

Enhancements:
- Implements token storage in Redis to associate access tokens with refresh tokens.
- Introduces a new method in the token repository to store access and refresh tokens.
- Adds a helper function to generate key names for access and refresh tokens.
- Refactors the token invalidation script to improve readability and efficiency.