### PR TITLE
refactor(error_responder): add error responder utility function that …

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"blockstracker_backend/config"
 	apperrors "blockstracker_backend/internal/errors"
+	"blockstracker_backend/messages"
 	"blockstracker_backend/models"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"go.uber.org/zap"
 )
 
 const (
@@ -83,4 +85,11 @@ func ParseToken(tokenString string, authConfig *config.AuthConfig) (*models.Clai
 		return claims, nil
 	}
 	return nil, apperrors.ErrInvalidToken
+}
+
+func SendErrorResponse(c *gin.Context, logger *zap.SugaredLogger, logTitle string,
+	logErrMsg string, resErr *apperrors.AuthError) {
+
+	logger.Errorw(logTitle, messages.Error, logErrMsg)
+	c.JSON(resErr.StatusCode(), CreateJSONResponse(messages.Error, resErr.Error(), nil))
 }


### PR DESCRIPTION
…will be used by all middleware and handlers

## Summary by Sourcery

Introduce a utility function for sending error responses from Gin handlers and middleware, and use it in the AuthMiddleware.

Enhancements:
- Introduce SendErrorResponse utility function to centralize error response logic.
- Refactor AuthMiddleware to use the new SendErrorResponse function for sending error responses.