### PR TITLE
refactor(signup): use SendErrorResponse utility function in signout handler

### DIFF
--- a/internal/errors/auth_errors.go
+++ b/internal/errors/auth_errors.go
@@ -27,15 +27,25 @@ func (e *AuthError) Error() string {
 	return e.message
 }
 
+func (e *AuthError) SetErrMessage(message string) {
+	e.message = message
+}
+
 func (e *AuthError) LogError() string {
 	return fmt.Sprintf("AuthError - Code: %s, Message: %s, Status Code: %d", e.code, e.message, e.statusCode)
 }
 
 var (
-	ErrUnauthorized            = NewAuthError("UNAUTHORIZED", "Unauthorized", http.StatusUnauthorized)
-	ErrNoAuthorizationHeader   = NewAuthError("NO_AUTH_HEADER", "No Authorization header", http.StatusUnauthorized)
-	ErrInvalidAuthHeader       = NewAuthError("INVALID_AUTH_HEADER", "Invalid Authorization header", http.StatusUnauthorized)
-	ErrTokenExpired            = NewAuthError("TOKEN_EXPIRED", "Token expired", http.StatusUnauthorized)
-	ErrInvalidToken            = NewAuthError("INVALID_TOKEN", "Invalid token", http.StatusUnauthorized)
-	ErrUnexpectedSigningMethod = NewAuthError("UNEXPECTED_SIGNING_METHOD", "Unexpected signing method", http.StatusUnauthorized)
+	ErrUnauthorized             = NewAuthError("UNAUTHORIZED", "Unauthorized", http.StatusUnauthorized)
+	ErrNoAuthorizationHeader    = NewAuthError("NO_AUTH_HEADER", "No Authorization header", http.StatusUnauthorized)
+	ErrInvalidAuthHeader        = NewAuthError("INVALID_AUTH_HEADER", "Invalid Authorization header", http.StatusUnauthorized)
+	ErrTokenExpired             = NewAuthError("TOKEN_EXPIRED", "Token expired", http.StatusUnauthorized)
+	ErrInvalidToken             = NewAuthError("INVALID_TOKEN", "Invalid token", http.StatusUnauthorized)
+	ErrUnexpectedSigningMethod  = NewAuthError("UNEXPECTED_SIGNING_METHOD", "Unexpected signing method", http.StatusUnauthorized)
+	ErrMalformedRequest         = NewAuthError("BAD_REQUEST", "Malformed request", http.StatusBadRequest)
+	ErrInternalServerError      = NewAuthError("INTERNAL_SERVER_ERROR", "Internal server error", http.StatusInternalServerError)
+	ErrDBUniqueConstraintFailed = NewAuthError("DB_UNIQUE_CONSTRAINT_FAILED", "Internal server error", http.StatusInternalServerError)
+	ErrUniqueConstraintFailed   = NewAuthError("UNIQUE_CONSTRAINT_FAILED", "Unique constraint failed", http.StatusBadRequest)
+	ErrInvalidRequestBody       = NewAuthError("INVALID_REQUEST_BODY", "Invalid request body", http.StatusBadRequest)
+	ErrUserCreationFailed       = NewAuthError("USER_CREATION_FAILED", "User creation failed", http.StatusBadRequest)
 )


### PR DESCRIPTION
## Summary by Sourcery

Refactors the signup handler to use the SendErrorResponse utility function for sending error responses. This change improves code consistency and simplifies error handling within the handler.

Enhancements:
- Replaces direct JSON responses with the SendErrorResponse utility function for error handling in the signup handler.
- Introduces specific error types for request validation, malformed requests, password hashing, and user creation failures.