### PR TITLE
docs(auth-routes): add swagger docs for auth routes

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 tasks:
   migrate-up:
@@ -10,7 +10,7 @@ tasks:
     cmds:
       - goose down
     description: "Rollback goose migrations (down)"
-  
+
   unit-test:
     cmds:
       - go test ./tests/unit... -v
@@ -25,3 +25,8 @@ tasks:
     cmds:
       - go test ./tests/... -v
     description: "Run all tests"
+
+  generate-swagger:
+    cmds:
+      - swag init -g cmd/main.go
+    description: "Generate swagger spec"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,9 +18,13 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
-// @title Your API Title
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+
+// @title Blockstracker
 // @version 1.0
-// @description This is your API description.
+// @description Blockstracker API
 // @host localhost:5000
 // @BasePath /api/v1
 func main() {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,138 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/auth/signin": {
+            "post": {
+                "description": "Sign in with email and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign in with email and password",
+                "parameters": [
+                    {
+                        "description": "User sign in request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.EmailSignInRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User sign in successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.SignInSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid Credentials",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/signout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Invalidates the user's access and refresh tokens",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign out user",
+                "responses": {
+                    "200": {
+                        "description": "User sign out successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/signup": {
+            "post": {
+                "description": "Signs up a new user with email and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign up a new user",
+                "parameters": [
+                    {
+                        "description": "User sign up request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.SignUpRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User creation successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ping": {
             "get": {
                 "description": "Returns pong",
@@ -32,6 +164,126 @@ const docTemplate = `{
                 }
             }
         }
+    },
+    "definitions": {
+        "models.EmailSignInRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "test@example.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "Strongpassword123"
+                }
+            }
+        },
+        "models.ErrorResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Error message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Error"
+                }
+            }
+        },
+        "models.GenericErrorResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.ErrorResult"
+                }
+            }
+        },
+        "models.GenericSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.SuccessResult"
+                }
+            }
+        },
+        "models.SignInSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.SignInSuccessResult"
+                }
+            }
+        },
+        "models.SignInSuccessResult": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.TokenResponse"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
+        "models.SignUpRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "test@example.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "Strongpassword123"
+                }
+            }
+        },
+        "models.SuccessResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
+        "models.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "accessToken": {
+                    "type": "string"
+                },
+                "refreshToken": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
     }
 }`
 
@@ -41,8 +293,8 @@ var SwaggerInfo = &swag.Spec{
 	Host:             "localhost:5000",
 	BasePath:         "/api/v1",
 	Schemes:          []string{},
-	Title:            "Your API Title",
-	Description:      "This is your API description.",
+	Title:            "Blockstracker",
+	Description:      "Blockstracker API",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,14 +1,146 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "This is your API description.",
-        "title": "Your API Title",
+        "description": "Blockstracker API",
+        "title": "Blockstracker",
         "contact": {},
         "version": "1.0"
     },
     "host": "localhost:5000",
     "basePath": "/api/v1",
     "paths": {
+        "/auth/signin": {
+            "post": {
+                "description": "Sign in with email and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign in with email and password",
+                "parameters": [
+                    {
+                        "description": "User sign in request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.EmailSignInRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User sign in successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.SignInSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid Credentials",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/signout": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Invalidates the user's access and refresh tokens",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign out user",
+                "responses": {
+                    "200": {
+                        "description": "User sign out successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/signup": {
+            "post": {
+                "description": "Signs up a new user with email and password",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Sign up a new user",
+                "parameters": [
+                    {
+                        "description": "User sign up request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.SignUpRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User creation successful",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericSuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Malformed Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ping": {
             "get": {
                 "description": "Returns pong",
@@ -25,6 +157,126 @@
                     }
                 }
             }
+        }
+    },
+    "definitions": {
+        "models.EmailSignInRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "test@example.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "Strongpassword123"
+                }
+            }
+        },
+        "models.ErrorResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Error message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Error"
+                }
+            }
+        },
+        "models.GenericErrorResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.ErrorResult"
+                }
+            }
+        },
+        "models.GenericSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.SuccessResult"
+                }
+            }
+        },
+        "models.SignInSuccessResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/definitions/models.SignInSuccessResult"
+                }
+            }
+        },
+        "models.SignInSuccessResult": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.TokenResponse"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
+        "models.SignUpRequest": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "example": "test@example.com"
+                },
+                "password": {
+                    "type": "string",
+                    "example": "Strongpassword123"
+                }
+            }
+        },
+        "models.SuccessResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
+        "models.TokenResponse": {
+            "type": "object",
+            "properties": {
+                "accessToken": {
+                    "type": "string"
+                },
+                "refreshToken": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,11 +1,172 @@
 basePath: /api/v1
+definitions:
+  models.EmailSignInRequest:
+    properties:
+      email:
+        example: test@example.com
+        type: string
+      password:
+        example: Strongpassword123
+        type: string
+    required:
+    - email
+    - password
+    type: object
+  models.ErrorResult:
+    properties:
+      message:
+        example: Error message
+        type: string
+      status:
+        example: Error
+        type: string
+    type: object
+  models.GenericErrorResponse:
+    properties:
+      result:
+        $ref: '#/definitions/models.ErrorResult'
+    type: object
+  models.GenericSuccessResponse:
+    properties:
+      result:
+        $ref: '#/definitions/models.SuccessResult'
+    type: object
+  models.SignInSuccessResponse:
+    properties:
+      result:
+        $ref: '#/definitions/models.SignInSuccessResult'
+    type: object
+  models.SignInSuccessResult:
+    properties:
+      data:
+        $ref: '#/definitions/models.TokenResponse'
+      message:
+        example: Success message
+        type: string
+      status:
+        example: Success
+        type: string
+    type: object
+  models.SignUpRequest:
+    properties:
+      email:
+        example: test@example.com
+        type: string
+      password:
+        example: Strongpassword123
+        type: string
+    required:
+    - email
+    - password
+    type: object
+  models.SuccessResult:
+    properties:
+      message:
+        example: Success message
+        type: string
+      status:
+        example: Success
+        type: string
+    type: object
+  models.TokenResponse:
+    properties:
+      accessToken:
+        type: string
+      refreshToken:
+        type: string
+    type: object
 host: localhost:5000
 info:
   contact: {}
-  description: This is your API description.
-  title: Your API Title
+  description: Blockstracker API
+  title: Blockstracker
   version: "1.0"
 paths:
+  /auth/signin:
+    post:
+      consumes:
+      - application/json
+      description: Sign in with email and password
+      parameters:
+      - description: User sign in request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/models.EmailSignInRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User sign in successful
+          schema:
+            $ref: '#/definitions/models.SignInSuccessResponse'
+        "400":
+          description: Malformed Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "401":
+          description: Invalid Credentials
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Sign in with email and password
+      tags:
+      - auth
+  /auth/signout:
+    post:
+      consumes:
+      - application/json
+      description: Invalidates the user's access and refresh tokens
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User sign out successful
+          schema:
+            $ref: '#/definitions/models.GenericSuccessResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Sign out user
+      tags:
+      - auth
+  /auth/signup:
+    post:
+      consumes:
+      - application/json
+      description: Signs up a new user with email and password
+      parameters:
+      - description: User sign up request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/models.SignUpRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User creation successful
+          schema:
+            $ref: '#/definitions/models.GenericSuccessResponse'
+        "400":
+          description: Malformed Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Sign up a new user
+      tags:
+      - auth
   /ping:
     get:
       description: Returns pong
@@ -17,4 +178,9 @@ paths:
       summary: Ping example
       tags:
       - example
+securityDefinitions:
+  BearerAuth:
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"

--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	_ "blockstracker_backend/docs"
 	apperrors "blockstracker_backend/internal/errors"
 	"blockstracker_backend/internal/repositories"
 	messages "blockstracker_backend/messages"
@@ -42,6 +43,17 @@ func NewAuthHandler(
 	}
 }
 
+// SignupUser godoc
+// @Summary      Sign up a new user
+// @Description  Signs up a new user with email and password
+// @Tags         auth
+// @Accept       json
+// @Produce      json
+// @Param        request body models.SignUpRequest true "User sign up request"
+// @Success      200  {object}  models.GenericSuccessResponse "User creation successful"
+// @Failure      400  {object}  models.GenericErrorResponse "Malformed Request"
+// @Failure      500  {object}  models.GenericErrorResponse "Internal Server Error"
+// @Router       /auth/signup [post]
 func (h *AuthHandler) SignupUser(c *gin.Context) {
 	var req models.SignUpRequest
 
@@ -95,6 +107,31 @@ func (h *AuthHandler) SignupUser(c *gin.Context) {
 		utils.CreateJSONResponse(messages.Success, messages.MsgUserCreationSuccess, nil))
 }
 
+type SignInSuccessResponse struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+}
+
+type ResponseWithData[T any] struct {
+	Result struct {
+		Status  string `json:"status" example:"success"`
+		Message string `json:"message" example:"User created successfully"`
+		Data    T      `json:"data,omitempty"`
+	} `json:"result"`
+}
+
+// EmailSignIn godoc
+// @Summary      Sign in with email and password
+// @Description  Sign in with email and password
+// @Tags         auth
+// @Accept       json
+// @Produce      json
+// @Param        request body models.EmailSignInRequest true "User sign in request"
+// @Success      200  {object}  models.SignInSuccessResponse "User sign in successful"
+// @Failure      400  {object}  models.GenericErrorResponse  "Malformed Request"
+// @Failure      401  {object}  models.GenericErrorResponse  "Invalid Credentials"
+// @Failure      500  {object}  models.GenericErrorResponse "Internal Server Error"
+// @Router       /auth/signin [post]
 func (h *AuthHandler) EmailSignIn(c *gin.Context) {
 	var req models.EmailSignInRequest
 
@@ -154,6 +191,15 @@ func (h *AuthHandler) EmailSignIn(c *gin.Context) {
 		}))
 }
 
+// @Summary      Sign out user
+// @Description  Invalidates the user's access and refresh tokens
+// @Tags         auth
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  models.GenericSuccessResponse "User sign out successful"
+// @Failure      500  {object}  models.GenericErrorResponse "Internal Server Error"
+// @Router       /auth/signout [post]
 func (h *AuthHandler) Signout(c *gin.Context) {
 	authHeader := c.GetHeader("Authorization")
 	token, _ := utils.ExtractBearerToken(authHeader)

--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -107,19 +107,6 @@ func (h *AuthHandler) SignupUser(c *gin.Context) {
 		utils.CreateJSONResponse(messages.Success, messages.MsgUserCreationSuccess, nil))
 }
 
-type SignInSuccessResponse struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken"`
-}
-
-type ResponseWithData[T any] struct {
-	Result struct {
-		Status  string `json:"status" example:"success"`
-		Message string `json:"message" example:"User created successfully"`
-		Data    T      `json:"data,omitempty"`
-	} `json:"result"`
-}
-
 // EmailSignIn godoc
 // @Summary      Sign in with email and password
 // @Description  Sign in with email and password

--- a/models/user.go
+++ b/models/user.go
@@ -19,17 +19,51 @@ type User struct {
 }
 
 type SignUpRequest struct {
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required,strongpassword"`
+	Email    string `json:"email" binding:"required,email" example:"test@example.com"`
+	Password string `json:"password" binding:"required,strongpassword" example:"Strongpassword123"`
 }
 
 type EmailSignInRequest struct {
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required"`
+	Email    string `json:"email" binding:"required,email" example:"test@example.com"`
+	Password string `json:"password" binding:"required" example:"Strongpassword123"`
 }
 
 type Claims struct {
 	UserID uuid.UUID `json:"user_id"`
 	Email  string    `json:"email"`
 	jwt.RegisteredClaims
+}
+
+// Response example structs for swagger
+type GenericSuccessResponse struct {
+	Result SuccessResult `json:"result"`
+}
+
+type GenericErrorResponse struct {
+	Result ErrorResult `json:"result"`
+}
+
+type SignInSuccessResponse struct {
+	Result SignInSuccessResult `json:"result"`
+}
+
+type SignInSuccessResult struct {
+	Status  string        `json:"status" example:"Success"`
+	Message string        `json:"message" example:"Success message"`
+	Data    TokenResponse `json:"data"`
+}
+
+type SuccessResult struct {
+	Status  string `json:"status" example:"Success"`
+	Message string `json:"message" example:"Success message"`
+}
+
+type ErrorResult struct {
+	Status  string `json:"status" example:"Error"`
+	Message string `json:"message" example:"Error message"`
+}
+
+type TokenResponse struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
 }


### PR DESCRIPTION
## Summary by Sourcery

Adds Swagger documentation for the authentication routes, including sign-up, sign-in, and sign-out endpoints. This enhances API discoverability and provides a clear contract for developers.

Documentation:
- Adds Swagger documentation for the authentication routes, including sign-up, sign-in, and sign-out endpoints.
- Updates the API title and description in the Swagger documentation.
- Defines security definitions for Bearer authentication in the Swagger documentation.