### PR TITLE
docs(create task): add docs for create task route

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -215,9 +215,135 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/task/create": {
+            "post": {
+                "description": "Create a new task with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new task",
+                "parameters": [
+                    {
+                        "description": "Task details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateTaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateTaskResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "models.CreateTaskRequest": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplate": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CreateTaskResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Task"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.EmailSignInRequest": {
             "type": "object",
             "required": [
@@ -281,6 +407,83 @@ const docTemplate = `{
                 }
             }
         },
+        "models.RepetitiveTaskTemplate": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "friday": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "lastDateOfTaskGeneration": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "monday": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "saturday": {
+                    "type": "boolean"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "space": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "spaceId": {
+                    "type": "integer"
+                },
+                "sunday": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                },
+                "thursday": {
+                    "type": "boolean"
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "tuesday": {
+                    "type": "boolean"
+                },
+                "wednesday": {
+                    "type": "boolean"
+                }
+            }
+        },
         "models.SignInSuccessResponse": {
             "type": "object",
             "properties": {
@@ -322,6 +525,35 @@ const docTemplate = `{
                 }
             }
         },
+        "models.Space": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repetitiveTasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                }
+            }
+        },
         "models.SuccessResult": {
             "type": "object",
             "properties": {
@@ -332,6 +564,109 @@ const docTemplate = `{
                 "status": {
                     "type": "string",
                     "example": "Success"
+                }
+            }
+        },
+        "models.Tag": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repetitiveTasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                }
+            }
+        },
+        "models.Task": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplate": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "space": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "userId": {
+                    "description": "Add UserID here",
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -209,9 +209,135 @@
                     }
                 }
             }
+        },
+        "/task/create": {
+            "post": {
+                "description": "Create a new task with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new task",
+                "parameters": [
+                    {
+                        "description": "Task details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateTaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateTaskResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "models.CreateTaskRequest": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplate": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CreateTaskResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Task"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.EmailSignInRequest": {
             "type": "object",
             "required": [
@@ -275,6 +401,83 @@
                 }
             }
         },
+        "models.RepetitiveTaskTemplate": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "friday": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "lastDateOfTaskGeneration": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "monday": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "saturday": {
+                    "type": "boolean"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "space": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "spaceId": {
+                    "type": "integer"
+                },
+                "sunday": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                },
+                "thursday": {
+                    "type": "boolean"
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "tuesday": {
+                    "type": "boolean"
+                },
+                "wednesday": {
+                    "type": "boolean"
+                }
+            }
+        },
         "models.SignInSuccessResponse": {
             "type": "object",
             "properties": {
@@ -316,6 +519,35 @@
                 }
             }
         },
+        "models.Space": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repetitiveTasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                }
+            }
+        },
         "models.SuccessResult": {
             "type": "object",
             "properties": {
@@ -326,6 +558,109 @@
                 "status": {
                     "type": "string",
                     "example": "Success"
+                }
+            }
+        },
+        "models.Tag": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "repetitiveTasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                }
+            }
+        },
+        "models.Task": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplate": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "space": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "userId": {
+                    "description": "Add UserID here",
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,60 @@
 basePath: /api/v1
 definitions:
+  models.CreateTaskRequest:
+    properties:
+      completionStatus:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      dueDate:
+        type: string
+      isActive:
+        type: boolean
+      modifiedAt:
+        type: string
+      priority:
+        type: integer
+      repetitiveTaskTemplate:
+        $ref: '#/definitions/models.RepetitiveTaskTemplate'
+      repetitiveTaskTemplateId:
+        type: string
+      schedule:
+        type: string
+      score:
+        type: integer
+      shouldBeScored:
+        type: boolean
+      spaceId:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/models.Tag'
+        type: array
+      timeOfDay:
+        type: string
+      title:
+        type: string
+    required:
+    - completionStatus
+    - isActive
+    - priority
+    - schedule
+    - shouldBeScored
+    - title
+    type: object
+  models.CreateTaskResponseForSwagger:
+    properties:
+      message:
+        example: Success message
+        type: string
+      result:
+        $ref: '#/definitions/models.Task'
+      status:
+        example: Success
+        type: string
+    type: object
   models.EmailSignInRequest:
     properties:
       email:
@@ -43,6 +98,57 @@ definitions:
     - accessToken
     - refreshToken
     type: object
+  models.RepetitiveTaskTemplate:
+    properties:
+      createdAt:
+        type: string
+      description:
+        type: string
+      friday:
+        type: boolean
+      id:
+        type: string
+      isActive:
+        type: boolean
+      lastDateOfTaskGeneration:
+        type: string
+      modifiedAt:
+        type: string
+      monday:
+        type: boolean
+      priority:
+        type: integer
+      saturday:
+        type: boolean
+      schedule:
+        type: string
+      shouldBeScored:
+        type: boolean
+      space:
+        $ref: '#/definitions/models.Space'
+      spaceId:
+        type: integer
+      sunday:
+        type: boolean
+      tags:
+        items:
+          $ref: '#/definitions/models.Tag'
+        type: array
+      tasks:
+        items:
+          $ref: '#/definitions/models.Task'
+        type: array
+      thursday:
+        type: boolean
+      timeOfDay:
+        type: string
+      title:
+        type: string
+      tuesday:
+        type: boolean
+      wednesday:
+        type: boolean
+    type: object
   models.SignInSuccessResponse:
     properties:
       result:
@@ -71,6 +177,25 @@ definitions:
     - email
     - password
     type: object
+  models.Space:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: string
+      modifiedAt:
+        type: string
+      name:
+        type: string
+      repetitiveTasks:
+        items:
+          $ref: '#/definitions/models.RepetitiveTaskTemplate'
+        type: array
+      tasks:
+        items:
+          $ref: '#/definitions/models.Task'
+        type: array
+    type: object
   models.SuccessResult:
     properties:
       message:
@@ -79,6 +204,76 @@ definitions:
       status:
         example: Success
         type: string
+    type: object
+  models.Tag:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: string
+      modifiedAt:
+        type: string
+      name:
+        type: string
+      repetitiveTasks:
+        items:
+          $ref: '#/definitions/models.RepetitiveTaskTemplate'
+        type: array
+      tasks:
+        items:
+          $ref: '#/definitions/models.Task'
+        type: array
+    type: object
+  models.Task:
+    properties:
+      completionStatus:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      dueDate:
+        type: string
+      id:
+        type: string
+      isActive:
+        type: boolean
+      modifiedAt:
+        type: string
+      priority:
+        type: integer
+      repetitiveTaskTemplate:
+        $ref: '#/definitions/models.RepetitiveTaskTemplate'
+      repetitiveTaskTemplateId:
+        type: string
+      schedule:
+        type: string
+      score:
+        type: integer
+      shouldBeScored:
+        type: boolean
+      space:
+        $ref: '#/definitions/models.Space'
+      spaceId:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/models.Tag'
+        type: array
+      timeOfDay:
+        type: string
+      title:
+        type: string
+      userId:
+        description: Add UserID here
+        type: string
+    required:
+    - completionStatus
+    - isActive
+    - priority
+    - schedule
+    - shouldBeScored
+    - title
     type: object
   models.TokenResponse:
     properties:
@@ -224,6 +419,36 @@ paths:
       summary: Ping example
       tags:
       - example
+  /task/create:
+    post:
+      consumes:
+      - application/json
+      description: Create a new task with the given details
+      parameters:
+      - description: Task details
+        in: body
+        name: task
+        required: true
+        schema:
+          $ref: '#/definitions/models.CreateTaskRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CreateTaskResponseForSwagger'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Create a new task
+      tags:
+      - tasks
 securityDefinitions:
   BearerAuth:
     in: header

--- a/handlers/task_handlers.go
+++ b/handlers/task_handlers.go
@@ -30,6 +30,17 @@ func NewTaskHandler(
 	}
 }
 
+// CreateTask godoc
+// @Summary Create a new task
+// @Description Create a new task with the given details
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param task body models.CreateTaskRequest true "Task details"
+// @Success 200 {object} models.CreateTaskResponseForSwagger
+// @Failure 400 {object} models.GenericErrorResponse
+// @Failure 500 {object} models.GenericErrorResponse
+// @Router /task/create [post]
 func (h *TaskHandler) CreateTask(c *gin.Context) {
 	userID, ok := c.Get("userID")
 	if !ok {

--- a/models/common.go
+++ b/models/common.go
@@ -1,0 +1,19 @@
+package models
+
+type GenericSuccessResponse struct {
+	Result SuccessResult `json:"result"`
+}
+
+type GenericErrorResponse struct {
+	Result ErrorResult `json:"result"`
+}
+
+type SuccessResult struct {
+	Status  string `json:"status" example:"Success"`
+	Message string `json:"message" example:"Success message"`
+}
+
+type ErrorResult struct {
+	Status  string `json:"status" example:"Error"`
+	Message string `json:"message" example:"Error message"`
+}

--- a/models/task.go
+++ b/models/task.go
@@ -23,7 +23,6 @@ type CreateTaskRequest struct {
 	CreatedAt                time.Time               `json:"createdAt"`
 	ModifiedAt               time.Time               `json:"modifiedAt"`
 	Tags                     []Tag                   `gorm:"many2many:task_tags;" json:"tags"`
-	Space                    *Space                  `json:"space"`
 	SpaceID                  *uuid.UUID              `gorm:"type:uuid" json:"spaceId"`
 	DeletedAt                gorm.DeletedAt          `gorm:"index" json:"-"`
 }
@@ -49,6 +48,12 @@ type Task struct {
 	SpaceID                  *uuid.UUID              `gorm:"type:uuid" json:"spaceId"`
 	UserID                   uuid.UUID               `gorm:"type:uuid" json:"userId"` // Add UserID here
 	DeletedAt                gorm.DeletedAt          `gorm:"index" json:"-"`
+}
+
+// Create Task success response for swagger doc
+type CreateTaskResponseForSwagger struct {
+	Result Task `json:"result"`
+	SuccessResult
 }
 
 type RepetitiveTaskTemplate struct {

--- a/models/user.go
+++ b/models/user.go
@@ -40,14 +40,6 @@ type Claims struct {
 }
 
 // Response example structs for swagger
-type GenericSuccessResponse struct {
-	Result SuccessResult `json:"result"`
-}
-
-type GenericErrorResponse struct {
-	Result ErrorResult `json:"result"`
-}
-
 type SignInSuccessResponse struct {
 	Result SignInSuccessResult `json:"result"`
 }
@@ -56,16 +48,6 @@ type SignInSuccessResult struct {
 	Status  string        `json:"status" example:"Success"`
 	Message string        `json:"message" example:"Success message"`
 	Data    TokenResponse `json:"data"`
-}
-
-type SuccessResult struct {
-	Status  string `json:"status" example:"Success"`
-	Message string `json:"message" example:"Success message"`
-}
-
-type ErrorResult struct {
-	Status  string `json:"status" example:"Error"`
-	Message string `json:"message" example:"Error message"`
 }
 
 type TokenResponse struct {


### PR DESCRIPTION
## Summary by Sourcery

Adds documentation for the create task route, including request and response models, and updates the swagger documentation.

Documentation:
- Adds documentation for the create task route, including request and response models.
- Updates the swagger documentation to include the new create task route and its associated models.