### PR TITLE
test(create-tag): add integration tests for create tags route

### DIFF
--- a/models/tag.go
+++ b/models/tag.go
@@ -17,7 +17,7 @@ type Tag struct {
 }
 
 type CreateTagRequest struct {
-	Name       string    `json:"name"`
-	CreatedAt  time.Time `json:"createdAt"`
-	ModifiedAt time.Time `json:"modifiedAt"`
+	Name       string    `json:"name" binding:"required"`
+	CreatedAt  time.Time `json:"createdAt" binding:"required"`
+	ModifiedAt time.Time `json:"modifiedAt" binding:"required"`
 }

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -213,6 +213,7 @@ func setupRouter() error {
 	}
 
 	taskRepo := repositories.NewTaskRepository(TestDB)
+	tagRepo := repositories.NewTagRepository(TestDB)
 
 	logger := zap.NewNop().Sugar()
 
@@ -221,6 +222,7 @@ func setupRouter() error {
 	authHandler := handlers.NewAuthHandler(userRepo, logger, testAuthConfig, tokenRepository)
 	authMiddleware := middleware.NewAuthMiddleware(logger, testAuthConfig)
 	taskHandler := handlers.NewTaskHandler(taskRepo, logger)
+	tagHandler := handlers.NewTagHandler(tagRepo, logger)
 
 	router = gin.Default()
 	router.POST("/signup", authHandler.SignupUser)
@@ -233,6 +235,9 @@ func setupRouter() error {
 
 	taskGroup := router.Group("/task")
 	taskGroup.POST("/create", authMiddleware.Handle, taskHandler.CreateTask)
+
+	tagGroup := router.Group("/tags")
+	tagGroup.POST("/", authMiddleware.Handle, tagHandler.CreateTag)
 
 	return nil
 }

--- a/tests/integration/tag_test.go
+++ b/tests/integration/tag_test.go
@@ -1,0 +1,128 @@
+package integration
+
+import (
+	"blockstracker_backend/messages"
+	"blockstracker_backend/tests/integration/testutils"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTagIntegration(t *testing.T) {
+	// First, sign in a user to get a valid access token
+	signInReqBody := map[string]string{"email": "test@example.com", "password": "StrongPassword123!"}
+	signInReq, err := testutils.CreateRequest(http.MethodPost, "/signin", signInReqBody)
+	if err != nil {
+		t.Fatalf("Error creating sign-in request: %v", err)
+	}
+	signInResp := httptest.NewRecorder()
+	router.ServeHTTP(signInResp, signInReq)
+	assert.Equal(t, http.StatusOK, signInResp.Code, "Sign-in failed")
+
+	var signInResponseBody map[string]interface{}
+	err = json.Unmarshal(signInResp.Body.Bytes(), &signInResponseBody)
+	assert.NoError(t, err)
+	result, ok := signInResponseBody["result"].(map[string]interface{})
+	assert.True(t, ok)
+	data, ok := result["data"].(map[string]interface{})
+	assert.True(t, ok)
+	accessToken, ok := data["accessToken"].(string)
+	assert.True(t, ok)
+
+	testCases := []struct {
+		name           string
+		requestBody    map[string]interface{}
+		expectedStatus int
+	}{
+		{
+			name: "Success - Valid Tag Creation",
+			requestBody: map[string]interface{}{
+				"name":       "Test Tag",
+				"createdAt":  "2025-03-21T06:33:44.183Z",
+				"modifiedAt": "2025-03-21T06:33:44.184Z",
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Failure - Missing Name",
+			requestBody: map[string]interface{}{
+				"createdAt":  "2025-03-21T06:33:44.183Z",
+				"modifiedAt": "2025-03-21T06:33:44.184Z",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Failure - Missing createdAt",
+			requestBody: map[string]interface{}{
+				"name":       "Test Tag",
+				"modifiedAt": "2025-03-21T06:33:44.184Z",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Failure - Missing modifiedAt",
+			requestBody: map[string]interface{}{
+				"name":      "Test Tag",
+				"createdAt": "2025-03-21T06:33:44.183Z",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Failure - Invalid createdAt",
+			requestBody: map[string]interface{}{
+				"name":       "Test Tag",
+				"createdAt":  "invalid-date",
+				"modifiedAt": "2025-03-21T06:33:44.184Z",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Failure - Invalid modifiedAt",
+			requestBody: map[string]interface{}{
+				"name":       "Test Tag",
+				"createdAt":  "invalid-date",
+				"modifiedAt": "invalid-date",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := testutils.CreateRequest(
+				http.MethodPost,
+				"/tags/",
+				tc.requestBody,
+				testutils.WithAccessToken(accessToken),
+			)
+			if err != nil {
+				t.Fatalf("Error creating request: %v", err)
+			}
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, tc.expectedStatus, resp.Code, "Unexpected status code")
+
+			if tc.expectedStatus == http.StatusOK {
+				var responseBody map[string]interface{}
+				err = json.Unmarshal(resp.Body.Bytes(), &responseBody)
+				assert.NoError(t, err)
+				result, ok := responseBody["result"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, messages.Success, result["status"])
+				assert.Equal(t, messages.MsgTagCreationSuccess, result["message"])
+				data, ok := result["data"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.NotEmpty(t, data["id"])
+				assert.Equal(t, tc.requestBody["name"], data["name"])
+				assert.Equal(t, tc.requestBody["createdAt"], data["createdAt"])
+				assert.Equal(t, tc.requestBody["modifiedAt"], data["modifiedAt"])
+				assert.NotEmpty(t, data["userId"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Adds integration tests for the create tag route, covering success and failure scenarios.