### PR TITLE
feat(create space): add create space route

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,11 @@ func main() {
 		log.Fatalf("Error initializing tag handler: %s", err.Error())
 	}
 
+	spaceHandler, err := di.InitializeSpaceHandler()
+	if err != nil {
+		log.Fatalf("Error initializing space handler: %s", err.Error())
+	}
+
 	r := gin.Default()
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
@@ -62,6 +67,7 @@ func main() {
 		routes.RegisterAuthRoutes(v1, authHandler, authMiddleware)
 		routes.RegisterTaskRoutes(v1, taskHandler, authMiddleware)
 		routes.RegisterTagRoutes(v1, tagHandler, authMiddleware)
+		routes.RegisterSpaceRoutes(v1, spaceHandler, authMiddleware)
 	}
 
 	fmt.Println(strings.Repeat("🚀", 25))

--- a/di/wire.go
+++ b/di/wire.go
@@ -57,3 +57,13 @@ func InitializeTagHandler() (*handlers.TagHandler, error) {
 	)
 	return &handlers.TagHandler{}, nil
 }
+
+func InitializeSpaceHandler() (*handlers.SpaceHandler, error) {
+	wire.Build(
+		database.DBProvider,
+		repositories.NewSpaceRepository,
+		logger.LoggerProvider,
+		handlers.NewSpaceHandler,
+	)
+	return &handlers.SpaceHandler{}, nil
+}

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -64,3 +64,11 @@ func InitializeTagHandler() (*handlers.TagHandler, error) {
 	tagHandler := handlers.NewTagHandler(tagRepository, sugaredLogger)
 	return tagHandler, nil
 }
+
+func InitializeSpaceHandler() (*handlers.SpaceHandler, error) {
+	db := database.DBProvider()
+	spaceRepository := repositories.NewSpaceRepository(db)
+	sugaredLogger := logger.LoggerProvider()
+	spaceHandler := handlers.NewSpaceHandler(spaceRepository, sugaredLogger)
+	return spaceHandler, nil
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -216,6 +216,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/spaces": {
+            "post": {
+                "description": "Create a new Space with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Spaces"
+                ],
+                "summary": "Create a new Space",
+                "parameters": [
+                    {
+                        "description": "Space details",
+                        "name": "Space",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateSpaceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateSpaceResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tags": {
             "post": {
                 "description": "Create a new tag with the given details",
@@ -310,6 +356,41 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "models.CreateSpaceRequest": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "modifiedAt",
+                "name"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CreateSpaceResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.CreateTagRequest": {
             "type": "object",
             "required": [
@@ -608,6 +689,11 @@ const docTemplate = `{
         },
         "models.Space": {
             "type": "object",
+            "required": [
+                "createdAt",
+                "modifiedAt",
+                "name"
+            ],
             "properties": {
                 "createdAt": {
                     "type": "string"
@@ -621,17 +707,8 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
-                "repetitiveTasks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
-                    }
-                },
-                "tasks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Task"
-                    }
+                "userId": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -210,6 +210,52 @@
                 }
             }
         },
+        "/spaces": {
+            "post": {
+                "description": "Create a new Space with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Spaces"
+                ],
+                "summary": "Create a new Space",
+                "parameters": [
+                    {
+                        "description": "Space details",
+                        "name": "Space",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateSpaceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateSpaceResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/tags": {
             "post": {
                 "description": "Create a new tag with the given details",
@@ -304,6 +350,41 @@
         }
     },
     "definitions": {
+        "models.CreateSpaceRequest": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "modifiedAt",
+                "name"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.CreateSpaceResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Space"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.CreateTagRequest": {
             "type": "object",
             "required": [
@@ -602,6 +683,11 @@
         },
         "models.Space": {
             "type": "object",
+            "required": [
+                "createdAt",
+                "modifiedAt",
+                "name"
+            ],
             "properties": {
                 "createdAt": {
                     "type": "string"
@@ -615,17 +701,8 @@
                 "name": {
                     "type": "string"
                 },
-                "repetitiveTasks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.RepetitiveTaskTemplate"
-                    }
-                },
-                "tasks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Task"
-                    }
+                "userId": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,29 @@
 basePath: /api/v1
 definitions:
+  models.CreateSpaceRequest:
+    properties:
+      createdAt:
+        type: string
+      modifiedAt:
+        type: string
+      name:
+        type: string
+    required:
+    - createdAt
+    - modifiedAt
+    - name
+    type: object
+  models.CreateSpaceResponseForSwagger:
+    properties:
+      message:
+        example: Success message
+        type: string
+      result:
+        $ref: '#/definitions/models.Space'
+      status:
+        example: Success
+        type: string
+    type: object
   models.CreateTagRequest:
     properties:
       createdAt:
@@ -211,14 +235,12 @@ definitions:
         type: string
       name:
         type: string
-      repetitiveTasks:
-        items:
-          $ref: '#/definitions/models.RepetitiveTaskTemplate'
-        type: array
-      tasks:
-        items:
-          $ref: '#/definitions/models.Task'
-        type: array
+      userId:
+        type: string
+    required:
+    - createdAt
+    - modifiedAt
+    - name
     type: object
   models.SuccessResult:
     properties:
@@ -441,6 +463,36 @@ paths:
       summary: Ping example
       tags:
       - example
+  /spaces:
+    post:
+      consumes:
+      - application/json
+      description: Create a new Space with the given details
+      parameters:
+      - description: Space details
+        in: body
+        name: Space
+        required: true
+        schema:
+          $ref: '#/definitions/models.CreateSpaceRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CreateSpaceResponseForSwagger'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Create a new Space
+      tags:
+      - Spaces
   /tags:
     post:
       consumes:

--- a/handlers/space_handlers.go
+++ b/handlers/space_handlers.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"net/http"
+
+	apperrors "blockstracker_backend/internal/errors"
+	"blockstracker_backend/internal/repositories"
+	"blockstracker_backend/internal/utils"
+	"blockstracker_backend/messages"
+	"blockstracker_backend/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type SpaceHandler struct {
+	SpaceRepo *repositories.SpaceRepository
+	logger    *zap.SugaredLogger
+}
+
+func NewSpaceHandler(
+	SpaceRepo *repositories.SpaceRepository,
+	logger *zap.SugaredLogger,
+) *SpaceHandler {
+	return &SpaceHandler{
+		SpaceRepo: SpaceRepo,
+		logger:    logger,
+	}
+}
+
+// CreateSpace godoc
+// @Summary Create a new Space
+// @Description Create a new Space with the given details
+// @Tags Spaces
+// @Accept json
+// @Produce json
+// @Param Space body models.CreateSpaceRequest true "Space details"
+// @Success 200 {object} models.CreateSpaceResponseForSwagger
+// @Failure 400 {object} models.GenericErrorResponse
+// @Failure 500 {object} models.GenericErrorResponse
+// @Router /spaces [post]
+func (h *SpaceHandler) CreateSpace(c *gin.Context) {
+	userID, ok := c.Get("userID")
+	if !ok {
+		utils.SendErrorResponse(c, h.logger, messages.ErrSpaceCreationFailed,
+			"User ID not found in context", apperrors.ErrInternalServerError)
+		return
+	}
+
+	uid, ok := userID.(uuid.UUID)
+	if !ok {
+		utils.SendErrorResponse(c, h.logger, messages.ErrSpaceCreationFailed,
+			"User ID is not of valid type", apperrors.ErrInternalServerError)
+		return
+	}
+
+	var req models.CreateSpaceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		invalidReqErr := apperrors.NewInvalidReqErr(err.Error())
+		utils.SendErrorResponse(c, h.logger, messages.ErrSpaceCreationFailed,
+			err.Error(), invalidReqErr)
+		return
+	}
+
+	Space := models.Space{
+		Name:       req.Name,
+		CreatedAt:  req.CreatedAt,
+		ModifiedAt: req.ModifiedAt,
+		UserID:     uid,
+	}
+
+	if err := h.SpaceRepo.CreateSpace(&Space); err != nil {
+		utils.SendErrorResponse(c, h.logger, messages.ErrSpaceCreationFailed,
+			err.Error(), apperrors.ErrInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, utils.CreateJSONResponse(
+		messages.Success, messages.MsgSpaceCreationSuccess, Space))
+}
+
+func (h *SpaceHandler) UpdateSpace(c *gin.Context) {
+}
+
+func (h *SpaceHandler) GetSpacesFromVersion(c *gin.Context) {
+}

--- a/internal/repositories/space_repository.go
+++ b/internal/repositories/space_repository.go
@@ -1,0 +1,19 @@
+package repositories
+
+import (
+	"blockstracker_backend/models"
+
+	"gorm.io/gorm"
+)
+
+type SpaceRepository struct {
+	db *gorm.DB
+}
+
+func NewSpaceRepository(db *gorm.DB) *SpaceRepository {
+	return &SpaceRepository{db: db}
+}
+
+func (r *SpaceRepository) CreateSpace(Space *models.Space) error {
+	return r.db.Create(Space).Error
+}

--- a/messages/error.go
+++ b/messages/error.go
@@ -36,4 +36,6 @@ const (
 	ErrTaskCreationFailed = "Task creation failed"
 
 	ErrTagCreationFailed = "Tag creation failed"
+
+	ErrSpaceCreationFailed = "Space creation failed"
 )

--- a/messages/success.go
+++ b/messages/success.go
@@ -11,4 +11,7 @@ const (
 
 	MsgTagCreationSuccess = "Tag creation successful"
 	MsgTagUpdatedSuccess  = "Tag updated successfully"
+
+	MsgSpaceCreationSuccess = "Space creation successful"
+	MsgSpaceUpdatedSuccess  = "Space updated successfully"
 )

--- a/models/space.go
+++ b/models/space.go
@@ -8,11 +8,22 @@ import (
 )
 
 type Space struct {
-	ID              uuid.UUID                `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	Name            string                   `gorm:"unique;not null" json:"name"`
-	Tasks           []Task                   `json:"tasks"`
-	RepetitiveTasks []RepetitiveTaskTemplate `json:"repetitiveTasks"`
-	CreatedAt       time.Time                `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt      time.Time                `gorm:"autoUpdateTime" json:"modifiedAt"`
-	DeletedAt       gorm.DeletedAt           `gorm:"index" json:"-"`
+	ID         uuid.UUID      `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	Name       string         `json:"name" binding:"required"`
+	CreatedAt  time.Time      `json:"createdAt" binding:"required"`
+	ModifiedAt time.Time      `json:"modifiedAt" binding:"required"`
+	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID     uuid.UUID      `gorm:"type:uuid;index" json:"userId"`
+}
+
+type CreateSpaceRequest struct {
+	Name       string    `json:"name" binding:"required"`
+	CreatedAt  time.Time `json:"createdAt" binding:"required"`
+	ModifiedAt time.Time `json:"modifiedAt" binding:"required"`
+}
+
+// Create Space success response for swagger doc
+type CreateSpaceResponseForSwagger struct {
+	Result Space `json:"result"`
+	SuccessResult
 }

--- a/routes/space_routes.go
+++ b/routes/space_routes.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"blockstracker_backend/handlers"
+	"blockstracker_backend/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterSpaceRoutes(rg *gin.RouterGroup, spaceHandler *handlers.SpaceHandler, authMiddleware *middleware.AuthMiddleware) {
+
+	spaceGroup := rg.Group("/spaces")
+	spaceGroup.Use(authMiddleware.Handle)
+
+	{
+		spaceGroup.POST("/", spaceHandler.CreateSpace)
+		spaceGroup.PUT("/:id", spaceHandler.UpdateSpace)
+		spaceGroup.GET("/", spaceHandler.GetSpacesFromVersion)
+	}
+}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -214,6 +214,7 @@ func setupRouter() error {
 
 	taskRepo := repositories.NewTaskRepository(TestDB)
 	tagRepo := repositories.NewTagRepository(TestDB)
+	spaceRepo := repositories.NewSpaceRepository(TestDB)
 
 	logger := zap.NewNop().Sugar()
 
@@ -223,6 +224,7 @@ func setupRouter() error {
 	authMiddleware := middleware.NewAuthMiddleware(logger, testAuthConfig)
 	taskHandler := handlers.NewTaskHandler(taskRepo, logger)
 	tagHandler := handlers.NewTagHandler(tagRepo, logger)
+	spaceHandler := handlers.NewSpaceHandler(spaceRepo, logger)
 
 	router = gin.Default()
 	router.POST("/signup", authHandler.SignupUser)
@@ -240,6 +242,9 @@ func setupRouter() error {
 
 	tagGroup := router.Group("/tags")
 	tagGroup.POST("/", tagHandler.CreateTag)
+
+	spaceGroup := router.Group("/spaces")
+	spaceGroup.POST("/", spaceHandler.CreateSpace)
 
 	return nil
 }

--- a/tests/integration/space_test.go
+++ b/tests/integration/space_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateTagIntegration(t *testing.T) {
+func TestCreateSpaceIntegration(t *testing.T) {
 	// First, sign in a user to get a valid access token
 	signInReqBody := map[string]string{"email": "test@example.com", "password": "StrongPassword123!"}
 	signInReq, err := testutils.CreateRequest(http.MethodPost, "/signin", signInReqBody)
@@ -39,9 +39,9 @@ func TestCreateTagIntegration(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name: "Success - Valid Tag Creation",
+			name: "Success - Valid Space Creation",
 			requestBody: map[string]interface{}{
-				"name":       "Test Tag",
+				"name":       "Test Space",
 				"createdAt":  time.Now().UTC().Format(time.RFC3339Nano),
 				"modifiedAt": time.Now().UTC().Format(time.RFC3339Nano),
 			},
@@ -56,36 +56,45 @@ func TestCreateTagIntegration(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name: "Failure - Missing createdAt",
+			name: "Failure - Missing CreatedAt",
 			requestBody: map[string]interface{}{
-				"name":       "Test Tag",
+				"name":       "Test Space",
 				"modifiedAt": time.Now().UTC().Format(time.RFC3339Nano),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name: "Failure - Missing modifiedAt",
+			name: "Failure - Missing ModifiedAt",
 			requestBody: map[string]interface{}{
-				"name":      "Test Tag",
+				"name":      "Test Space",
 				"createdAt": time.Now().UTC().Format(time.RFC3339Nano),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name: "Failure - Invalid createdAt",
+			name: "Failure - Invalid CreatedAt Format",
 			requestBody: map[string]interface{}{
-				"name":       "Test Tag",
+				"name":       "Test Space",
 				"createdAt":  "invalid-date",
 				"modifiedAt": time.Now().UTC().Format(time.RFC3339Nano),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name: "Failure - Invalid modifiedAt",
+			name: "Failure - Invalid ModifiedAt Format",
 			requestBody: map[string]interface{}{
-				"name":       "Test Tag",
-				"createdAt":  "invalid-date",
+				"name":       "Test Space",
+				"createdAt":  time.Now().UTC().Format(time.RFC3339Nano),
 				"modifiedAt": "invalid-date",
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "Failure - Empty Name",
+			requestBody: map[string]interface{}{
+				"name":       "",
+				"createdAt":  time.Now().UTC().Format(time.RFC3339Nano),
+				"modifiedAt": time.Now().UTC().Format(time.RFC3339Nano),
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
@@ -95,7 +104,7 @@ func TestCreateTagIntegration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			req, err := testutils.CreateRequest(
 				http.MethodPost,
-				"/tags/",
+				"/spaces/",
 				tc.requestBody,
 				testutils.WithAccessToken(accessToken),
 			)
@@ -115,7 +124,7 @@ func TestCreateTagIntegration(t *testing.T) {
 				result, ok := responseBody["result"].(map[string]interface{})
 				assert.True(t, ok)
 				assert.Equal(t, messages.Success, result["status"])
-				assert.Equal(t, messages.MsgTagCreationSuccess, result["message"])
+				assert.Equal(t, messages.MsgSpaceCreationSuccess, result["message"])
 				data, ok := result["data"].(map[string]interface{})
 				assert.True(t, ok)
 				assert.NotEmpty(t, data["id"])


### PR DESCRIPTION
## Summary by Sourcery

Introduces the ability to create spaces via a new API endpoint. This includes defining the request and response models, integrating the new handler and repository, and adding integration tests.

New Features:
- Adds a new API endpoint to create spaces.
- Implements integration tests for the new space creation endpoint.

Tests:
- Adds integration tests for space creation, covering success and failure scenarios, including missing or invalid fields.