### PR TITLE
feat(create repetitive task template): add repetitive task template creation route

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -353,9 +353,158 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/tasks/repetitive": {
+            "post": {
+                "description": "Create a new repetitive task template with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new repetitive task template",
+                "parameters": [
+                    {
+                        "description": "Repetitive task template details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateRepetitiveTaskTemplateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateRepetitiveTaskTemplateResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "models.CreateRepetitiveTaskTemplateRequest": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "friday",
+                "isActive",
+                "modifiedAt",
+                "monday",
+                "priority",
+                "saturday",
+                "schedule",
+                "shouldBeScored",
+                "sunday",
+                "thursday",
+                "title",
+                "tuesday",
+                "wednesday"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "friday": {
+                    "type": "boolean"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "lastDateOfTaskGeneration": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "monday": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "saturday": {
+                    "type": "boolean"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "sunday": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                },
+                "thursday": {
+                    "type": "boolean"
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "tuesday": {
+                    "type": "boolean"
+                },
+                "wednesday": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "models.CreateRepetitiveTaskTemplateResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.CreateSpaceRequest": {
             "type": "object",
             "required": [
@@ -571,6 +720,14 @@ const docTemplate = `{
         },
         "models.RepetitiveTaskTemplate": {
             "type": "object",
+            "required": [
+                "isActive",
+                "monday",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
             "properties": {
                 "createdAt": {
                     "type": "string"
@@ -612,7 +769,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/models.Space"
                 },
                 "spaceId": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "sunday": {
                     "type": "boolean"
@@ -640,6 +797,10 @@ const docTemplate = `{
                 },
                 "tuesday": {
                     "type": "boolean"
+                },
+                "userId": {
+                    "description": "Add UserID here",
+                    "type": "string"
                 },
                 "wednesday": {
                     "type": "boolean"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -347,9 +347,158 @@
                     }
                 }
             }
+        },
+        "/tasks/repetitive": {
+            "post": {
+                "description": "Create a new repetitive task template with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Create a new repetitive task template",
+                "parameters": [
+                    {
+                        "description": "Repetitive task template details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateRepetitiveTaskTemplateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CreateRepetitiveTaskTemplateResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "models.CreateRepetitiveTaskTemplateRequest": {
+            "type": "object",
+            "required": [
+                "createdAt",
+                "friday",
+                "isActive",
+                "modifiedAt",
+                "monday",
+                "priority",
+                "saturday",
+                "schedule",
+                "shouldBeScored",
+                "sunday",
+                "thursday",
+                "title",
+                "tuesday",
+                "wednesday"
+            ],
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "friday": {
+                    "type": "boolean"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "lastDateOfTaskGeneration": {
+                    "type": "string"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "monday": {
+                    "type": "boolean"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "saturday": {
+                    "type": "boolean"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "sunday": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Task"
+                    }
+                },
+                "thursday": {
+                    "type": "boolean"
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "tuesday": {
+                    "type": "boolean"
+                },
+                "wednesday": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "models.CreateRepetitiveTaskTemplateResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
+                }
+            }
+        },
         "models.CreateSpaceRequest": {
             "type": "object",
             "required": [
@@ -565,6 +714,14 @@
         },
         "models.RepetitiveTaskTemplate": {
             "type": "object",
+            "required": [
+                "isActive",
+                "monday",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
             "properties": {
                 "createdAt": {
                     "type": "string"
@@ -606,7 +763,7 @@
                     "$ref": "#/definitions/models.Space"
                 },
                 "spaceId": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "sunday": {
                     "type": "boolean"
@@ -634,6 +791,10 @@
                 },
                 "tuesday": {
                     "type": "boolean"
+                },
+                "userId": {
+                    "description": "Add UserID here",
+                    "type": "string"
                 },
                 "wednesday": {
                     "type": "boolean"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,78 @@
 basePath: /api/v1
 definitions:
+  models.CreateRepetitiveTaskTemplateRequest:
+    properties:
+      createdAt:
+        type: string
+      description:
+        type: string
+      friday:
+        type: boolean
+      isActive:
+        type: boolean
+      lastDateOfTaskGeneration:
+        type: string
+      modifiedAt:
+        type: string
+      monday:
+        type: boolean
+      priority:
+        type: integer
+      saturday:
+        type: boolean
+      schedule:
+        type: string
+      shouldBeScored:
+        type: boolean
+      spaceId:
+        type: string
+      sunday:
+        type: boolean
+      tags:
+        items:
+          $ref: '#/definitions/models.Tag'
+        type: array
+      tasks:
+        items:
+          $ref: '#/definitions/models.Task'
+        type: array
+      thursday:
+        type: boolean
+      timeOfDay:
+        type: string
+      title:
+        type: string
+      tuesday:
+        type: boolean
+      wednesday:
+        type: boolean
+    required:
+    - createdAt
+    - friday
+    - isActive
+    - modifiedAt
+    - monday
+    - priority
+    - saturday
+    - schedule
+    - shouldBeScored
+    - sunday
+    - thursday
+    - title
+    - tuesday
+    - wednesday
+    type: object
+  models.CreateRepetitiveTaskTemplateResponseForSwagger:
+    properties:
+      message:
+        example: Success message
+        type: string
+      result:
+        $ref: '#/definitions/models.RepetitiveTaskTemplate'
+      status:
+        example: Success
+        type: string
+    type: object
   models.CreateSpaceRequest:
     properties:
       createdAt:
@@ -175,7 +248,7 @@ definitions:
       space:
         $ref: '#/definitions/models.Space'
       spaceId:
-        type: integer
+        type: string
       sunday:
         type: boolean
       tags:
@@ -194,8 +267,18 @@ definitions:
         type: string
       tuesday:
         type: boolean
+      userId:
+        description: Add UserID here
+        type: string
       wednesday:
         type: boolean
+    required:
+    - isActive
+    - monday
+    - priority
+    - schedule
+    - shouldBeScored
+    - title
     type: object
   models.SignInSuccessResponse:
     properties:
@@ -551,6 +634,36 @@ paths:
           schema:
             $ref: '#/definitions/models.GenericErrorResponse'
       summary: Create a new task
+      tags:
+      - tasks
+  /tasks/repetitive:
+    post:
+      consumes:
+      - application/json
+      description: Create a new repetitive task template with the given details
+      parameters:
+      - description: Repetitive task template details
+        in: body
+        name: task
+        required: true
+        schema:
+          $ref: '#/definitions/models.CreateRepetitiveTaskTemplateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CreateRepetitiveTaskTemplateResponseForSwagger'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Create a new repetitive task template
       tags:
       - tasks
 securityDefinitions:

--- a/handlers/task_handlers.go
+++ b/handlers/task_handlers.go
@@ -83,3 +83,63 @@ func (h *TaskHandler) CreateTask(c *gin.Context) {
 	c.JSON(http.StatusOK, utils.CreateJSONResponse(
 		messages.Success, messages.MsgTaskCreationSuccess, task))
 }
+
+// CreateRepetitiveTaskTemplate godoc
+// @Summary Create a new repetitive task template
+// @Description Create a new repetitive task template with the given details
+// @Tags tasks
+// @Accept json
+// @Produce json
+// @Param task body models.CreateRepetitiveTaskTemplateRequest true "Repetitive task template details"
+// @Success 200 {object} models.CreateRepetitiveTaskTemplateResponseForSwagger
+// @Failure 400 {object} models.GenericErrorResponse
+// @Failure 500 {object} models.GenericErrorResponse
+// @Router /tasks/repetitive [post]
+func (h *TaskHandler) CreateRepetitiveTaskTemplate(c *gin.Context) {
+	uid, err := utils.ExtractUIDFromGinContext(c)
+	if err != nil {
+		utils.SendErrorResponse(c, h.logger, messages.ErrRepetitiveTaskTemplateCreationFailed,
+			err.LogError(), apperrors.ErrInternalServerError)
+		return
+	}
+
+	var req models.CreateRepetitiveTaskTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		invalidReqErr := apperrors.NewInvalidReqErr(err.Error())
+		utils.SendErrorResponse(c, h.logger, messages.ErrRepetitiveTaskTemplateCreationFailed,
+			err.Error(), invalidReqErr)
+		return
+	}
+
+	repetitiveTaskTemplate := models.RepetitiveTaskTemplate{
+		IsActive:                 req.IsActive,
+		Title:                    req.Title,
+		Description:              req.Description,
+		Schedule:                 req.Schedule,
+		Priority:                 req.Priority,
+		ShouldBeScored:           req.ShouldBeScored,
+		Monday:                   req.Monday,
+		Tuesday:                  req.Tuesday,
+		Wednesday:                req.Wednesday,
+		Thursday:                 req.Thursday,
+		Friday:                   req.Friday,
+		Saturday:                 req.Saturday,
+		Sunday:                   req.Sunday,
+		TimeOfDay:                req.TimeOfDay,
+		LastDateOfTaskGeneration: req.LastDateOfTaskGeneration,
+		CreatedAt:                req.CreatedAt,
+		ModifiedAt:               req.ModifiedAt,
+		Tags:                     req.Tags,
+		SpaceID:                  req.SpaceID,
+		UserID:                   uid,
+	}
+
+	if err := h.taskRepo.CreateRepetitiveTaskTemplate(&repetitiveTaskTemplate); err != nil {
+		utils.SendErrorResponse(c, h.logger, messages.ErrTaskCreationFailed,
+			err.Error(), apperrors.ErrInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, utils.CreateJSONResponse(messages.Success,
+		messages.MsgRepetitiveTaskTemplateCreationSuccess, repetitiveTaskTemplate))
+}

--- a/internal/repositories/task_repository.go
+++ b/internal/repositories/task_repository.go
@@ -17,3 +17,7 @@ func NewTaskRepository(db *gorm.DB) *TaskRepository {
 func (r *TaskRepository) CreateTask(task *models.Task) error {
 	return r.db.Create(task).Error
 }
+
+func (r *TaskRepository) CreateRepetitiveTaskTemplate(repetitiveTaskTemplate *models.RepetitiveTaskTemplate) error {
+	return r.db.Create(repetitiveTaskTemplate).Error
+}

--- a/messages/error.go
+++ b/messages/error.go
@@ -35,6 +35,8 @@ const (
 
 	ErrTaskCreationFailed = "Task creation failed"
 
+	ErrRepetitiveTaskTemplateCreationFailed = "Repetitive task template creation failed"
+
 	ErrTagCreationFailed = "Tag creation failed"
 
 	ErrSpaceCreationFailed = "Space creation failed"

--- a/messages/success.go
+++ b/messages/success.go
@@ -1,13 +1,18 @@
 package messages
 
 const (
-	Success                   = "Success"
-	MsgUserCreationSuccess    = "User creation successful"
-	MsgSignInSuccessful       = "Sign in successful"
-	MsgTaskCreationSuccess    = "Task creation successful"
-	MsgTaskUpdatedSuccess     = "Task updated successfully"
+	Success                = "Success"
+	MsgUserCreationSuccess = "User creation successful"
+	MsgSignInSuccessful    = "Sign in successful"
+
+	MsgTaskCreationSuccess = "Task creation successful"
+	MsgTaskUpdatedSuccess  = "Task updated successfully"
+
 	MsgSignOutSuccessful      = "Sign out successful"
 	MsgSuccessfulTokenRefresh = "Successful token refresh"
+
+	MsgRepetitiveTaskTemplateCreationSuccess = "Repetitive task template creation successful"
+	MsgRepetitiveTaskTemplateUpdatedSuccess  = "Repetitive task template updated successfully"
 
 	MsgTagCreationSuccess = "Tag creation successful"
 	MsgTagUpdatedSuccess  = "Tag updated successfully"

--- a/models/task.go
+++ b/models/task.go
@@ -58,13 +58,13 @@ type CreateTaskResponseForSwagger struct {
 
 type RepetitiveTaskTemplate struct {
 	ID                       uuid.UUID      `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	IsActive                 bool           `gorm:"default:true" json:"isActive"`
-	Title                    string         `gorm:"not null" json:"title"`
+	IsActive                 bool           `gorm:"default:true" json:"isActive" binding:"required"`
+	Title                    string         `gorm:"not null" json:"title" binding:"required"`
 	Description              *string        `json:"description"`
-	Schedule                 string         `gorm:"not null" json:"schedule"`
-	Priority                 int            `gorm:"default:3" json:"priority"`
-	ShouldBeScored           *bool          `gorm:"default:false" json:"shouldBeScored"`
-	Monday                   *bool          `gorm:"default:false" json:"monday"`
+	Schedule                 string         `gorm:"not null" json:"schedule" binding:"required"`
+	Priority                 int            `gorm:"default:3" json:"priority" binding:"required"`
+	ShouldBeScored           *bool          `gorm:"default:false" json:"shouldBeScored" binding:"required"`
+	Monday                   *bool          `gorm:"default:false" json:"monday" binding:"required"`
 	Tuesday                  *bool          `gorm:"default:false" json:"tuesday"`
 	Wednesday                *bool          `gorm:"default:false" json:"wednesday"`
 	Thursday                 *bool          `gorm:"default:false" json:"thursday"`
@@ -73,13 +73,43 @@ type RepetitiveTaskTemplate struct {
 	Sunday                   *bool          `gorm:"default:false" json:"sunday"`
 	TimeOfDay                *string        `json:"timeOfDay"`
 	LastDateOfTaskGeneration *time.Time     `json:"lastDateOfTaskGeneration"`
-	CreatedAt                time.Time      `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt               time.Time      `gorm:"autoUpdateTime" json:"modifiedAt"`
+	CreatedAt                time.Time      `json:"createdAt"`
+	ModifiedAt               time.Time      `json:"modifiedAt"`
 	Tags                     []Tag          `gorm:"many2many:repetitive_task_template_tags" json:"tags"`
 	Tasks                    []Task         `json:"tasks"`
 	Space                    *Space         `json:"space"`
-	SpaceID                  *uint          `json:"spaceId"`
+	SpaceID                  *uuid.UUID     `gorm:"type:uuid" json:"spaceId"`
+	UserID                   uuid.UUID      `gorm:"type:uuid" json:"userId"` // Add UserID here
 	DeletedAt                gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+type CreateRepetitiveTaskTemplateRequest struct {
+	IsActive                 bool           `json:"isActive" binding:"required"`
+	Title                    string         `json:"title" binding:"required"`
+	Description              *string        `json:"description"`
+	Schedule                 string         `json:"schedule" binding:"required"`
+	Priority                 int            `json:"priority" binding:"required"`
+	ShouldBeScored           *bool          `json:"shouldBeScored" binding:"required"`
+	Monday                   *bool          `json:"monday" binding:"required"`
+	Tuesday                  *bool          `json:"tuesday" binding:"required"`
+	Wednesday                *bool          `json:"wednesday" binding:"required"`
+	Thursday                 *bool          `json:"thursday" binding:"required"`
+	Friday                   *bool          `json:"friday" binding:"required"`
+	Saturday                 *bool          `json:"saturday" binding:"required"`
+	Sunday                   *bool          `json:"sunday" binding:"required"`
+	TimeOfDay                *string        `json:"timeOfDay"`
+	LastDateOfTaskGeneration *time.Time     `json:"lastDateOfTaskGeneration"`
+	CreatedAt                time.Time      `json:"createdAt" binding:"required"`
+	ModifiedAt               time.Time      `json:"modifiedAt" binding:"required"`
+	Tags                     []Tag          `json:"tags"`
+	Tasks                    []Task         `json:"tasks"`
+	SpaceID                  *uuid.UUID     `json:"spaceId"`
+	DeletedAt                gorm.DeletedAt `json:"-"` // Keep json:"-" to omit from JSON
+}
+
+type CreateRepetitiveTaskTemplateResponseForSwagger struct {
+	Result RepetitiveTaskTemplate `json:"result"`
+	SuccessResult
 }
 
 type UpdateTaskRequest struct {

--- a/routes/task_routes.go
+++ b/routes/task_routes.go
@@ -13,5 +13,7 @@ func RegisterTaskRoutes(rg *gin.RouterGroup, taskHandler *handlers.TaskHandler, 
 
 	{
 		taskGroup.POST("/", taskHandler.CreateTask)
+
+		taskGroup.POST("/repetitive", taskHandler.CreateRepetitiveTaskTemplate)
 	}
 }

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -239,6 +239,7 @@ func setupRouter() error {
 
 	taskGroup := router.Group("/tasks")
 	taskGroup.POST("/", taskHandler.CreateTask)
+	taskGroup.POST("/repetitive", taskHandler.CreateRepetitiveTaskTemplate)
 
 	tagGroup := router.Group("/tags")
 	tagGroup.POST("/", tagHandler.CreateTag)

--- a/tests/integration/task_test.go
+++ b/tests/integration/task_test.go
@@ -180,3 +180,192 @@ func TestCreateTaskIntegration(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateRepetitiveTaskTemplateIntegration(t *testing.T) {
+	// First, sign in a user to get a valid access token
+	signInReqBody := map[string]string{"email": "test@example.com", "password": "StrongPassword123!"}
+	signInReq, err := testutils.CreateRequest(http.MethodPost, "/signin", signInReqBody)
+	if err != nil {
+		t.Fatalf("Error creating sign-in request: %v", err)
+	}
+	signInResp := httptest.NewRecorder()
+	router.ServeHTTP(signInResp, signInReq)
+	assert.Equal(t, http.StatusOK, signInResp.Code, "Sign-in failed")
+
+	var signInResponseBody map[string]interface{}
+	err = json.Unmarshal(signInResp.Body.Bytes(), &signInResponseBody)
+	assert.NoError(t, err)
+	result, ok := signInResponseBody["result"].(map[string]interface{})
+	assert.True(t, ok)
+	data, ok := result["data"].(map[string]interface{})
+	assert.True(t, ok)
+	accessToken, ok := data["accessToken"].(string)
+	assert.True(t, ok)
+
+	testCases := []struct {
+		name           string
+		requestBody    map[string]interface{}
+		expectedStatus int
+		expectedErrMsg string
+	}{
+		{
+			name: "Success - Valid Repetitive Task Template Creation",
+			requestBody: map[string]interface{}{
+				"isActive":                 true,
+				"title":                    "Test Repetitive Task Template",
+				"description":              "This is a test repetitive task template",
+				"schedule":                 "Specific Days in a Week",
+				"priority":                 3,
+				"shouldBeScored":           true,
+				"monday":                   true,
+				"tuesday":                  false,
+				"wednesday":                true,
+				"thursday":                 false,
+				"friday":                   true,
+				"saturday":                 false,
+				"sunday":                   true,
+				"timeOfDay":                "morning",
+				"lastDateOfTaskGeneration": time.Now().Add(7 * 24 * time.Hour).UTC().Format(time.RFC3339Nano),
+				"createdAt":                time.Now().UTC().Format(time.RFC3339Nano),
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano),
+				"tags":                     nil,
+				"spaceID":                  nil,
+			},
+			expectedStatus: http.StatusOK,
+			expectedErrMsg: messages.MsgRepetitiveTaskTemplateCreationSuccess,
+		},
+		{
+			name: "Failure - Missing Title",
+			requestBody: map[string]interface{}{
+				"isActive":                 true,
+				"description":              "This is a test repetitive task template",
+				"schedule":                 "Daily",
+				"priority":                 3,
+				"shouldBeScored":           true,
+				"monday":                   true,
+				"tuesday":                  true,
+				"wednesday":                true,
+				"thursday":                 true,
+				"friday":                   true,
+				"saturday":                 true,
+				"sunday":                   true,
+				"timeOfDay":                "morning",
+				"lastDateOfTaskGeneration": time.Now().Add(7 * 24 * time.Hour).UTC().Format(time.RFC3339Nano),
+				"createdAt":                time.Now().UTC().Format(time.RFC3339Nano),
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano),
+				"tags":                     nil,
+				"spaceID":                  nil,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedErrMsg: messages.ErrRepetitiveTaskTemplateCreationFailed,
+		},
+		{
+			name: "Failure - Invalid Last Date Of Task Generation Format",
+			requestBody: map[string]interface{}{
+				"isActive":                 true,
+				"title":                    "Test Repetitive Task Template",
+				"description":              "This is a test repetitive task template",
+				"schedule":                 "Daily",
+				"priority":                 3,
+				"shouldBeScored":           true,
+				"monday":                   true,
+				"tuesday":                  false,
+				"wednesday":                true,
+				"thursday":                 false,
+				"friday":                   true,
+				"saturday":                 false,
+				"sunday":                   true,
+				"timeOfDay":                "Morning",
+				"lastDateOfTaskGeneration": "invalid-date",
+				"createdAt":                time.Now().UTC().Format(time.RFC3339Nano),
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano),
+				"tags":                     nil,
+				"spaceID":                  nil,
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedErrMsg: messages.ErrRepetitiveTaskTemplateCreationFailed,
+		},
+		{
+			name: "Failure - Invalid Space ID",
+			requestBody: map[string]interface{}{
+				"isActive":                 true,
+				"title":                    "Test Repetitive Task Template",
+				"description":              "This is a test repetitive task template",
+				"schedule":                 "Daily",
+				"priority":                 3,
+				"shouldBeScored":           true,
+				"monday":                   true,
+				"tuesday":                  false,
+				"wednesday":                true,
+				"thursday":                 false,
+				"friday":                   true,
+				"saturday":                 false,
+				"sunday":                   true,
+				"timeOfDay":                "Morning",
+				"lastDateOfTaskGeneration": time.Now().Add(7 * 24 * time.Hour).UTC().Format(time.RFC3339Nano),
+				"createdAt":                time.Now().UTC().Format(time.RFC3339Nano),
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano),
+				"tags":                     nil,
+				"spaceID":                  "invalid-space-id",
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedErrMsg: messages.ErrRepetitiveTaskTemplateCreationFailed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := testutils.CreateRequest(
+				http.MethodPost,
+				"/tasks/repetitive",
+				tc.requestBody,
+				testutils.WithAccessToken(accessToken),
+			)
+			if err != nil {
+				t.Fatalf("Error creating request: %v", err)
+			}
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, tc.expectedStatus, resp.Code, "Unexpected status code")
+
+			if tc.expectedStatus == http.StatusOK {
+				assert.Contains(t, resp.Body.String(), tc.expectedErrMsg, "Expected error message not found")
+				var responseBody map[string]interface{}
+				err = json.Unmarshal(resp.Body.Bytes(), &responseBody)
+				assert.NoError(t, err)
+				result, ok := responseBody["result"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, messages.Success, result["status"])
+				assert.Equal(t, messages.MsgRepetitiveTaskTemplateCreationSuccess, result["message"])
+				data, ok := result["data"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.NotEmpty(t, data["id"])
+				assert.Equal(t, tc.requestBody["title"], data["title"])
+				assert.Equal(t, tc.requestBody["description"], data["description"])
+				assert.Equal(t, tc.requestBody["schedule"], data["schedule"])
+				if priorityFloat, ok := data["priority"].(float64); ok {
+					assert.Equal(t, tc.requestBody["priority"], int(priorityFloat))
+				} else {
+					t.Errorf("priority is not a float64: %v", data["priority"])
+				}
+				assert.Equal(t, tc.requestBody["shouldBeScored"], data["shouldBeScored"])
+				assert.Equal(t, tc.requestBody["monday"], data["monday"])
+				assert.Equal(t, tc.requestBody["tuesday"], data["tuesday"])
+				assert.Equal(t, tc.requestBody["wednesday"], data["wednesday"])
+				assert.Equal(t, tc.requestBody["thursday"], data["thursday"])
+				assert.Equal(t, tc.requestBody["friday"], data["friday"])
+				assert.Equal(t, tc.requestBody["saturday"], data["saturday"])
+				assert.Equal(t, tc.requestBody["sunday"], data["sunday"])
+				assert.Equal(t, tc.requestBody["timeOfDay"], data["timeOfDay"])
+				assert.Equal(t, tc.requestBody["lastDateOfTaskGeneration"], data["lastDateOfTaskGeneration"])
+				assert.Equal(t, tc.requestBody["createdAt"], data["createdAt"])
+				assert.Equal(t, tc.requestBody["modifiedAt"], data["modifiedAt"])
+				assert.Equal(t, tc.requestBody["tags"], data["tags"])
+				assert.Equal(t, tc.requestBody["spaceId"], data["spaceId"])
+				assert.NotEmpty(t, data["userId"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
…reation route

## Summary by Sourcery

Adds an endpoint to create repetitive task templates.

New Features:
- Introduces an API endpoint for creating repetitive task templates, allowing users to define tasks that recur on a schedule.

Tests:
- Adds integration tests for the new repetitive task template creation endpoint, covering both success and failure scenarios.