### PR TITLE
feat(update task): add update task route

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -328,7 +328,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.CreateTaskRequest"
+                            "$ref": "#/definitions/models.TaskRequest"
                         }
                     }
                 ],
@@ -336,7 +336,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.CreateTaskResponseForSwagger"
+                            "$ref": "#/definitions/models.TaskResponseForSwagger"
                         }
                     },
                     "400": {
@@ -387,6 +387,65 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/tasks/{id}": {
+            "put": {
+                "description": "Update an existing task with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Update an existing task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TaskResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.GenericErrorResponse"
                         }
@@ -568,86 +627,6 @@ const docTemplate = `{
                 },
                 "result": {
                     "$ref": "#/definitions/models.Tag"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "Success"
-                }
-            }
-        },
-        "models.CreateTaskRequest": {
-            "type": "object",
-            "required": [
-                "completionStatus",
-                "isActive",
-                "priority",
-                "schedule",
-                "shouldBeScored",
-                "title"
-            ],
-            "properties": {
-                "completionStatus": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "dueDate": {
-                    "type": "string"
-                },
-                "isActive": {
-                    "type": "boolean"
-                },
-                "modifiedAt": {
-                    "type": "string"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "repetitiveTaskTemplate": {
-                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
-                },
-                "repetitiveTaskTemplateId": {
-                    "type": "string"
-                },
-                "schedule": {
-                    "type": "string"
-                },
-                "score": {
-                    "type": "integer"
-                },
-                "shouldBeScored": {
-                    "type": "boolean"
-                },
-                "spaceId": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Tag"
-                    }
-                },
-                "timeOfDay": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.CreateTaskResponseForSwagger": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Success message"
-                },
-                "result": {
-                    "$ref": "#/definitions/models.Task"
                 },
                 "status": {
                     "type": "string",
@@ -982,6 +961,83 @@ const docTemplate = `{
                 "userId": {
                     "description": "Add UserID here",
                     "type": "string"
+                }
+            }
+        },
+        "models.TaskRequest": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TaskResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Task"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -322,7 +322,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.CreateTaskRequest"
+                            "$ref": "#/definitions/models.TaskRequest"
                         }
                     }
                 ],
@@ -330,7 +330,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.CreateTaskResponseForSwagger"
+                            "$ref": "#/definitions/models.TaskResponseForSwagger"
                         }
                     },
                     "400": {
@@ -381,6 +381,65 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/tasks/{id}": {
+            "put": {
+                "description": "Update an existing task with the given details",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasks"
+                ],
+                "summary": "Update an existing task",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Task ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Task details",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TaskResponseForSwagger"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.GenericErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.GenericErrorResponse"
                         }
@@ -562,86 +621,6 @@
                 },
                 "result": {
                     "$ref": "#/definitions/models.Tag"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "Success"
-                }
-            }
-        },
-        "models.CreateTaskRequest": {
-            "type": "object",
-            "required": [
-                "completionStatus",
-                "isActive",
-                "priority",
-                "schedule",
-                "shouldBeScored",
-                "title"
-            ],
-            "properties": {
-                "completionStatus": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "dueDate": {
-                    "type": "string"
-                },
-                "isActive": {
-                    "type": "boolean"
-                },
-                "modifiedAt": {
-                    "type": "string"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "repetitiveTaskTemplate": {
-                    "$ref": "#/definitions/models.RepetitiveTaskTemplate"
-                },
-                "repetitiveTaskTemplateId": {
-                    "type": "string"
-                },
-                "schedule": {
-                    "type": "string"
-                },
-                "score": {
-                    "type": "integer"
-                },
-                "shouldBeScored": {
-                    "type": "boolean"
-                },
-                "spaceId": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Tag"
-                    }
-                },
-                "timeOfDay": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.CreateTaskResponseForSwagger": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Success message"
-                },
-                "result": {
-                    "$ref": "#/definitions/models.Task"
                 },
                 "status": {
                     "type": "string",
@@ -976,6 +955,83 @@
                 "userId": {
                     "description": "Add UserID here",
                     "type": "string"
+                }
+            }
+        },
+        "models.TaskRequest": {
+            "type": "object",
+            "required": [
+                "completionStatus",
+                "isActive",
+                "priority",
+                "schedule",
+                "shouldBeScored",
+                "title"
+            ],
+            "properties": {
+                "completionStatus": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dueDate": {
+                    "type": "string"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "modifiedAt": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "repetitiveTaskTemplateId": {
+                    "type": "string"
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                },
+                "shouldBeScored": {
+                    "type": "boolean"
+                },
+                "spaceId": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Tag"
+                    }
+                },
+                "timeOfDay": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TaskResponseForSwagger": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "Success message"
+                },
+                "result": {
+                    "$ref": "#/definitions/models.Task"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "Success"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -121,61 +121,6 @@ definitions:
         example: Success
         type: string
     type: object
-  models.CreateTaskRequest:
-    properties:
-      completionStatus:
-        type: string
-      createdAt:
-        type: string
-      description:
-        type: string
-      dueDate:
-        type: string
-      isActive:
-        type: boolean
-      modifiedAt:
-        type: string
-      priority:
-        type: integer
-      repetitiveTaskTemplate:
-        $ref: '#/definitions/models.RepetitiveTaskTemplate'
-      repetitiveTaskTemplateId:
-        type: string
-      schedule:
-        type: string
-      score:
-        type: integer
-      shouldBeScored:
-        type: boolean
-      spaceId:
-        type: string
-      tags:
-        items:
-          $ref: '#/definitions/models.Tag'
-        type: array
-      timeOfDay:
-        type: string
-      title:
-        type: string
-    required:
-    - completionStatus
-    - isActive
-    - priority
-    - schedule
-    - shouldBeScored
-    - title
-    type: object
-  models.CreateTaskResponseForSwagger:
-    properties:
-      message:
-        example: Success message
-        type: string
-      result:
-        $ref: '#/definitions/models.Task'
-      status:
-        example: Success
-        type: string
-    type: object
   models.EmailSignInRequest:
     properties:
       email:
@@ -402,6 +347,59 @@ definitions:
     - shouldBeScored
     - title
     type: object
+  models.TaskRequest:
+    properties:
+      completionStatus:
+        type: string
+      createdAt:
+        type: string
+      description:
+        type: string
+      dueDate:
+        type: string
+      isActive:
+        type: boolean
+      modifiedAt:
+        type: string
+      priority:
+        type: integer
+      repetitiveTaskTemplateId:
+        type: string
+      schedule:
+        type: string
+      score:
+        type: integer
+      shouldBeScored:
+        type: boolean
+      spaceId:
+        type: string
+      tags:
+        items:
+          $ref: '#/definitions/models.Tag'
+        type: array
+      timeOfDay:
+        type: string
+      title:
+        type: string
+    required:
+    - completionStatus
+    - isActive
+    - priority
+    - schedule
+    - shouldBeScored
+    - title
+    type: object
+  models.TaskResponseForSwagger:
+    properties:
+      message:
+        example: Success message
+        type: string
+      result:
+        $ref: '#/definitions/models.Task'
+      status:
+        example: Success
+        type: string
+    type: object
   models.TokenResponse:
     properties:
       accessToken:
@@ -617,14 +615,14 @@ paths:
         name: task
         required: true
         schema:
-          $ref: '#/definitions/models.CreateTaskRequest'
+          $ref: '#/definitions/models.TaskRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.CreateTaskResponseForSwagger'
+            $ref: '#/definitions/models.TaskResponseForSwagger'
         "400":
           description: Bad Request
           schema:
@@ -634,6 +632,45 @@ paths:
           schema:
             $ref: '#/definitions/models.GenericErrorResponse'
       summary: Create a new task
+      tags:
+      - tasks
+  /tasks/{id}:
+    put:
+      consumes:
+      - application/json
+      description: Update an existing task with the given details
+      parameters:
+      - description: Task ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Task details
+        in: body
+        name: task
+        required: true
+        schema:
+          $ref: '#/definitions/models.TaskRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TaskResponseForSwagger'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.GenericErrorResponse'
+      summary: Update an existing task
       tags:
       - tasks
   /tasks/repetitive:

--- a/internal/repositories/task_repository.go
+++ b/internal/repositories/task_repository.go
@@ -18,6 +18,10 @@ func (r *TaskRepository) CreateTask(task *models.Task) error {
 	return r.db.Create(task).Error
 }
 
+func (r *TaskRepository) UpdateTask(task *models.Task) error {
+	return r.db.Save(task).Error
+}
+
 func (r *TaskRepository) CreateRepetitiveTaskTemplate(repetitiveTaskTemplate *models.RepetitiveTaskTemplate) error {
 	return r.db.Create(repetitiveTaskTemplate).Error
 }

--- a/messages/error.go
+++ b/messages/error.go
@@ -34,6 +34,7 @@ const (
 	ErrTokenNotFoundDuringLogout              = "Token not found during logout"
 
 	ErrTaskCreationFailed = "Task creation failed"
+	ErrTaskUpdateFailed   = "Task update failed"
 
 	ErrRepetitiveTaskTemplateCreationFailed = "Repetitive task template creation failed"
 

--- a/messages/success.go
+++ b/messages/success.go
@@ -6,7 +6,7 @@ const (
 	MsgSignInSuccessful    = "Sign in successful"
 
 	MsgTaskCreationSuccess = "Task creation successful"
-	MsgTaskUpdatedSuccess  = "Task updated successfully"
+	MsgTaskUpdateSuccess   = "Task updated successfully"
 
 	MsgSignOutSuccessful      = "Sign out successful"
 	MsgSuccessfulTokenRefresh = "Successful token refresh"

--- a/migrations/20250220130115_add_task_repetitivetasktemplate_space_tags_user_tables.sql
+++ b/migrations/20250220130115_add_task_repetitivetasktemplate_space_tags_user_tables.sql
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS repetitive_task_templates (
 CREATE INDEX idx_repetitive_task_templates_space_id ON repetitive_task_templates(space_id);
 CREATE INDEX idx_repetitive_task_templates_title ON repetitive_task_templates(title);
 
-CREATE TYPE task_status AS ENUM ('INCOMPLETE', 'FAILED', 'COMPLETED');
+CREATE TYPE task_status AS ENUM ('INCOMPLETE', 'FAILED', 'COMPLETE');
 
 CREATE TABLE IF NOT EXISTS tasks (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/models/task.go
+++ b/models/task.go
@@ -7,24 +7,24 @@ import (
 	"gorm.io/gorm"
 )
 
-type CreateTaskRequest struct {
-	IsActive                 bool                    `gorm:"default:true" json:"isActive" binding:"required"`
-	Title                    string                  `gorm:"not null" json:"title" binding:"required"`
-	Description              string                  `json:"description"`
-	Schedule                 string                  `json:"schedule" binding:"required"`
-	Priority                 int                     `gorm:"default:3" json:"priority" binding:"required"`
-	CompletionStatus         string                  `gorm:"default:'INCOMPLETE'" json:"completionStatus" binding:"required"`
-	DueDate                  *time.Time              `json:"dueDate"`
-	ShouldBeScored           *bool                   `json:"shouldBeScored" binding:"required"`
-	Score                    *int                    `json:"score"`
-	TimeOfDay                *string                 `json:"timeOfDay"`
-	RepetitiveTaskTemplate   *RepetitiveTaskTemplate `json:"repetitiveTaskTemplate"`
-	RepetitiveTaskTemplateID *uuid.UUID              `gorm:"type:uuid" json:"repetitiveTaskTemplateId"`
-	CreatedAt                time.Time               `json:"createdAt"`
-	ModifiedAt               time.Time               `json:"modifiedAt"`
-	Tags                     []Tag                   `gorm:"many2many:task_tags;" json:"tags"`
-	SpaceID                  *uuid.UUID              `gorm:"type:uuid" json:"spaceId"`
-	DeletedAt                gorm.DeletedAt          `gorm:"index" json:"-"`
+// todo:
+// change the name
+type TaskRequest struct {
+	IsActive                 bool       `json:"isActive" binding:"required"`
+	Title                    string     `json:"title" binding:"required"`
+	Description              string     `json:"description"`
+	Schedule                 string     `json:"schedule" binding:"required"`
+	Priority                 int        `json:"priority" binding:"required"`
+	CompletionStatus         string     `json:"completionStatus" binding:"required"`
+	DueDate                  *time.Time `json:"dueDate"`
+	ShouldBeScored           *bool      `json:"shouldBeScored" binding:"required"`
+	Score                    *int       `json:"score"`
+	TimeOfDay                *string    `json:"timeOfDay"`
+	RepetitiveTaskTemplateID *uuid.UUID `json:"repetitiveTaskTemplateId"`
+	CreatedAt                time.Time  `json:"createdAt" binding:"required"`
+	ModifiedAt               time.Time  `json:"modifiedAt" binding:"required"`
+	Tags                     []Tag      `gorm:"many2many:task_tags;" json:"tags"`
+	SpaceID                  *uuid.UUID `gorm:"type:uuid" json:"spaceId"`
 }
 
 type Task struct {
@@ -42,7 +42,7 @@ type Task struct {
 	RepetitiveTaskTemplate   *RepetitiveTaskTemplate `json:"repetitiveTaskTemplate"`
 	RepetitiveTaskTemplateID *uuid.UUID              `gorm:"type:uuid" json:"repetitiveTaskTemplateId"`
 	CreatedAt                time.Time               `json:"createdAt"`
-	ModifiedAt               time.Time               `json:"modifiedAt"`
+	ModifiedAt               time.Time               `json:"modifiedAt" binding:"required"`
 	Tags                     []Tag                   `gorm:"many2many:task_tags;" json:"tags"`
 	Space                    *Space                  `json:"space"`
 	SpaceID                  *uuid.UUID              `gorm:"type:uuid" json:"spaceId"`
@@ -51,7 +51,7 @@ type Task struct {
 }
 
 // Create Task success response for swagger doc
-type CreateTaskResponseForSwagger struct {
+type TaskResponseForSwagger struct {
 	Result Task `json:"result"`
 	SuccessResult
 }
@@ -110,13 +110,6 @@ type CreateRepetitiveTaskTemplateRequest struct {
 type CreateRepetitiveTaskTemplateResponseForSwagger struct {
 	Result RepetitiveTaskTemplate `json:"result"`
 	SuccessResult
-}
-
-type UpdateTaskRequest struct {
-	TaskID      int    `json:"task_id" binding:"required"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	DueDate     string `json:"due_date"`
 }
 
 type UpdateRepetitiveTaskRequest struct {

--- a/routes/task_routes.go
+++ b/routes/task_routes.go
@@ -13,6 +13,7 @@ func RegisterTaskRoutes(rg *gin.RouterGroup, taskHandler *handlers.TaskHandler, 
 
 	{
 		taskGroup.POST("/", taskHandler.CreateTask)
+		taskGroup.PUT("/:id", taskHandler.UpdateTask)
 
 		taskGroup.POST("/repetitive", taskHandler.CreateRepetitiveTaskTemplate)
 	}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -239,6 +239,7 @@ func setupRouter() error {
 
 	taskGroup := router.Group("/tasks")
 	taskGroup.POST("/", taskHandler.CreateTask)
+	taskGroup.PUT("/:id", taskHandler.UpdateTask)
 	taskGroup.POST("/repetitive", taskHandler.CreateRepetitiveTaskTemplate)
 
 	tagGroup := router.Group("/tags")

--- a/tests/integration/task_test.go
+++ b/tests/integration/task_test.go
@@ -2,13 +2,16 @@ package integration
 
 import (
 	"blockstracker_backend/messages"
+	"blockstracker_backend/models"
 	"blockstracker_backend/tests/integration/testutils"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -176,6 +179,205 @@ func TestCreateTaskIntegration(t *testing.T) {
 				assert.Equal(t, tc.requestBody["repetitiveTaskTemplateId"], data["repetitiveTaskTemplateId"])
 				assert.Equal(t, tc.requestBody["dueDate"], data["dueDate"])
 				assert.NotEmpty(t, data["userId"])
+			}
+		})
+	}
+}
+
+func TestUpdateTaskIntegration(t *testing.T) {
+	// First, sign in a user to get a valid access token
+	signInReqBody := map[string]string{"email": "test@example.com", "password": "StrongPassword123!"}
+	signInReq, err := testutils.CreateRequest(http.MethodPost, "/signin", signInReqBody)
+	if err != nil {
+		t.Fatalf("Error creating sign-in request: %v", err)
+	}
+	signInResp := httptest.NewRecorder()
+	router.ServeHTTP(signInResp, signInReq)
+	assert.Equal(t, http.StatusOK, signInResp.Code, "Sign-in failed")
+
+	var signInResponseBody map[string]interface{}
+	err = json.Unmarshal(signInResp.Body.Bytes(), &signInResponseBody)
+	assert.NoError(t, err)
+	result, ok := signInResponseBody["result"].(map[string]interface{})
+	assert.True(t, ok)
+	data, ok := result["data"].(map[string]interface{})
+	assert.True(t, ok)
+	accessToken, ok := data["accessToken"].(string)
+	assert.True(t, ok)
+
+	// Create a task to update
+	createTaskReqBody := map[string]interface{}{
+		"isActive":                 true,
+		"title":                    "Initial Task",
+		"description":              "Initial description",
+		"schedule":                 "Once",
+		"priority":                 3,
+		"completionStatus":         "INCOMPLETE",
+		"dueDate":                  time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339Nano),
+		"shouldBeScored":           true,
+		"score":                    5,
+		"timeOfDay":                "morning",
+		"repetitiveTaskTemplateID": nil,
+		"createdAt":                time.Now().UTC().Format(time.RFC3339Nano),
+		"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano),
+		"tags":                     nil,
+		"spaceID":                  nil,
+	}
+	createTaskReq, err := testutils.CreateRequest(http.MethodPost, "/tasks/", createTaskReqBody, testutils.WithAccessToken(accessToken))
+	if err != nil {
+		t.Fatalf("Error creating create task request: %v", err)
+	}
+	createTaskResp := httptest.NewRecorder()
+	router.ServeHTTP(createTaskResp, createTaskReq)
+	assert.Equal(t, http.StatusOK, createTaskResp.Code, "Create task failed")
+
+	var createTaskResponseBody map[string]interface{}
+	err = json.Unmarshal(createTaskResp.Body.Bytes(), &createTaskResponseBody)
+	assert.NoError(t, err)
+	createTaskResult, ok := createTaskResponseBody["result"].(map[string]interface{})
+	assert.True(t, ok)
+	createTaskData, ok := createTaskResult["data"].(map[string]interface{})
+	assert.True(t, ok)
+	taskID, ok := createTaskData["id"].(string)
+	assert.True(t, ok)
+
+	testCases := []struct {
+		name           string
+		requestBody    map[string]interface{}
+		expectedStatus int
+		expectedMsg    string
+	}{
+		{
+			name: "Success - Update Title",
+			requestBody: map[string]interface{}{
+				"title":                    "Updated Title", // Update the title
+				"isActive":                 createTaskReqBody["isActive"],
+				"description":              createTaskReqBody["description"],
+				"schedule":                 createTaskReqBody["schedule"],
+				"priority":                 createTaskReqBody["priority"],
+				"completionStatus":         createTaskReqBody["completionStatus"],
+				"dueDate":                  createTaskReqBody["dueDate"],
+				"shouldBeScored":           createTaskReqBody["shouldBeScored"],
+				"score":                    createTaskReqBody["score"],
+				"timeOfDay":                createTaskReqBody["timeOfDay"],
+				"repetitiveTaskTemplateId": createTaskReqBody["repetitiveTaskTemplateID"],
+				"createdAt":                createTaskReqBody["createdAt"],
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano), // Update modifiedAt
+				"tags":                     createTaskReqBody["tags"],
+				"spaceId":                  createTaskReqBody["spaceID"],
+			},
+			expectedStatus: http.StatusOK,
+			expectedMsg:    messages.MsgTaskUpdateSuccess,
+		},
+		{
+			name: "Success - Update Description",
+			requestBody: map[string]interface{}{
+				"title":                    createTaskReqBody["title"],
+				"isActive":                 createTaskReqBody["isActive"],
+				"description":              "Updated description",
+				"schedule":                 createTaskReqBody["schedule"],
+				"priority":                 createTaskReqBody["priority"],
+				"completionStatus":         createTaskReqBody["completionStatus"],
+				"dueDate":                  createTaskReqBody["dueDate"],
+				"shouldBeScored":           createTaskReqBody["shouldBeScored"],
+				"score":                    createTaskReqBody["score"],
+				"timeOfDay":                createTaskReqBody["timeOfDay"],
+				"repetitiveTaskTemplateId": createTaskReqBody["repetitiveTaskTemplateID"],
+				"createdAt":                createTaskReqBody["createdAt"],
+				"modifiedAt":               time.Now().UTC().Format(time.RFC3339Nano), // Update modifiedAt
+				"tags":                     createTaskReqBody["tags"],
+				"spaceId":                  createTaskReqBody["spaceID"],
+			},
+			expectedStatus: http.StatusOK,
+			expectedMsg:    messages.MsgTaskUpdateSuccess,
+		},
+		{
+			name: "Failure - Missing ModifiedAt",
+			requestBody: map[string]interface{}{
+				"title":                    createTaskReqBody["title"],
+				"isActive":                 createTaskReqBody["isActive"],
+				"description":              createTaskReqBody["description"],
+				"schedule":                 createTaskReqBody["schedule"],
+				"priority":                 createTaskReqBody["priority"],
+				"completionStatus":         createTaskReqBody["completionStatus"],
+				"dueDate":                  createTaskReqBody["dueDate"],
+				"shouldBeScored":           createTaskReqBody["shouldBeScored"],
+				"score":                    createTaskReqBody["score"],
+				"timeOfDay":                createTaskReqBody["timeOfDay"],
+				"repetitiveTaskTemplateId": createTaskReqBody["repetitiveTaskTemplateID"],
+				"createdAt":                createTaskReqBody["createdAt"],
+				"tags":                     createTaskReqBody["tags"],
+				"spaceId":                  createTaskReqBody["spaceID"],
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedMsg:    messages.ErrTaskUpdateFailed,
+		},
+		{
+			name: "Failure - Invalid ModifiedAt Format",
+			requestBody: map[string]interface{}{
+				"title":                    createTaskReqBody["title"],
+				"isActive":                 createTaskReqBody["isActive"],
+				"description":              createTaskReqBody["description"],
+				"schedule":                 createTaskReqBody["schedule"],
+				"priority":                 createTaskReqBody["priority"],
+				"completionStatus":         createTaskReqBody["completionStatus"],
+				"dueDate":                  createTaskReqBody["dueDate"],
+				"shouldBeScored":           createTaskReqBody["shouldBeScored"],
+				"score":                    createTaskReqBody["score"],
+				"timeOfDay":                createTaskReqBody["timeOfDay"],
+				"repetitiveTaskTemplateId": createTaskReqBody["repetitiveTaskTemplateID"],
+				"createdAt":                createTaskReqBody["createdAt"],
+				"modifiedAt":               "invalid-date",
+				"tags":                     createTaskReqBody["tags"],
+				"spaceId":                  createTaskReqBody["spaceID"],
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedMsg:    messages.ErrTaskUpdateFailed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := testutils.CreateRequest(
+				http.MethodPut,
+				fmt.Sprintf("/tasks/%s", taskID),
+				tc.requestBody,
+				testutils.WithAccessToken(accessToken),
+			)
+			if err != nil {
+				t.Fatalf("Error creating request: %v", err)
+			}
+
+			resp := httptest.NewRecorder()
+			router.ServeHTTP(resp, req)
+
+			assert.Equal(t, tc.expectedStatus, resp.Code, "Unexpected status code")
+
+			if tc.expectedStatus == http.StatusOK {
+				assert.Contains(t, resp.Body.String(), tc.expectedMsg, "Expected error message not found")
+				var responseBody map[string]interface{}
+				err = json.Unmarshal(resp.Body.Bytes(), &responseBody)
+				assert.NoError(t, err)
+				result, ok := responseBody["result"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, messages.Success, result["status"])
+				assert.Equal(t, messages.MsgTaskUpdateSuccess, result["message"])
+				data, ok := result["data"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.NotEmpty(t, data["id"])
+
+				// Retrieve the updated task from the database
+				updatedTask := &models.Task{ID: uuid.MustParse(taskID)}
+				err = TestDB.First(updatedTask).Error
+				assert.NoError(t, err)
+
+				// Check if the fields were updated correctly
+				if title, ok := tc.requestBody["title"].(string); ok {
+					assert.Equal(t, title, updatedTask.Title)
+				}
+				if description, ok := tc.requestBody["description"].(string); ok {
+					assert.Equal(t, description, updatedTask.Description)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary by Sourcery

Adds the ability to update tasks via a new PUT endpoint at `/tasks/{id}`. This includes modifications to the documentation, models, handlers, routes, and integration tests to support the new functionality.

New Features:
- Introduces a new PUT endpoint `/tasks/{id}` to update existing tasks.
- Adds integration tests for the new update task endpoint to ensure it functions correctly and handles various scenarios, including success and failure cases due to missing or invalid data.
- Adds the UpdateTask method to the TaskHandler to handle update task requests.
- Adds the UpdateTask method to the TaskRepository to update tasks in the database.
- Adds a route for updating tasks to the task routes

Enhancements:
- Updates the task model to include a modified at field.
- Updates swagger definitions to include TaskRequest and TaskResponseForSwagger

Tests:
- Adds integration tests for the new update task endpoint to ensure it functions correctly and handles various scenarios, including success and failure cases due to missing or invalid data.