### PR TITLE
fix(update task): stop one user to update task by another user

### DIFF
--- a/handlers/task_handlers.go
+++ b/handlers/task_handlers.go
@@ -146,7 +146,7 @@ func (h *TaskHandler) UpdateTask(c *gin.Context) {
 
 	if err := h.taskRepo.UpdateTask(&task); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			utils.SendErrorResponse(c, h.logger, messages.ErrTagUpdateFailed,
+			utils.SendErrorResponse(c, h.logger, messages.ErrTaskUpdateFailed,
 				"Task not found or does not belong to user", apperrors.ErrUnauthorized)
 			return
 		}

--- a/handlers/task_handlers.go
+++ b/handlers/task_handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
 type TaskHandler struct {
@@ -143,6 +145,12 @@ func (h *TaskHandler) UpdateTask(c *gin.Context) {
 	}
 
 	if err := h.taskRepo.UpdateTask(&task); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			utils.SendErrorResponse(c, h.logger, messages.ErrTagUpdateFailed,
+				"Task not found or does not belong to user", apperrors.ErrUnauthorized)
+			return
+		}
+
 		utils.SendErrorResponse(c, h.logger, messages.ErrTaskUpdateFailed,
 			err.Error(), apperrors.ErrInternalServerError)
 		return

--- a/internal/errors/auth_errors.go
+++ b/internal/errors/auth_errors.go
@@ -32,7 +32,6 @@ func (e *AuthError) LogError() string {
 }
 
 var (
-	ErrUnauthorized             = NewAuthError("UNAUTHORIZED", "Unauthorized", http.StatusUnauthorized)
 	ErrNoAuthorizationHeader    = NewAuthError("NO_AUTH_HEADER", "No Authorization header", http.StatusUnauthorized)
 	ErrInvalidAuthHeader        = NewAuthError("INVALID_AUTH_HEADER", "Invalid Authorization header", http.StatusUnauthorized)
 	ErrTokenExpired             = NewAuthError("TOKEN_EXPIRED", "Token expired", http.StatusUnauthorized)

--- a/internal/errors/common_errors.go
+++ b/internal/errors/common_errors.go
@@ -40,6 +40,7 @@ func NewInvalidReqErr(customMessage ...string) *CommonError {
 }
 
 var (
+	ErrUnauthorized            = NewCommonError("UNAUTHORIZED", "Unauthorized", http.StatusUnauthorized)
 	ErrInternalServerError     = NewCommonError("INTERNAL_SERVER_ERROR", "Internal server error", http.StatusInternalServerError)
 	ErrUserIDNotFoundInContext = NewCommonError("USER_ID_NOT_FOUND_IN_CONTEXT", "User ID not found in context", http.StatusInternalServerError)
 	ErrUserIDNotValidType      = NewCommonError("USER_ID_NOT_VALID_TYPE", "User ID is not of valid type", http.StatusInternalServerError)

--- a/internal/repositories/task_repository.go
+++ b/internal/repositories/task_repository.go
@@ -19,7 +19,14 @@ func (r *TaskRepository) CreateTask(task *models.Task) error {
 }
 
 func (r *TaskRepository) UpdateTask(task *models.Task) error {
-	return r.db.Save(task).Error
+	result := r.db.Model(&models.Task{}).Where("id = ? AND user_id = ?", task.ID, task.UserID).Updates(task)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 func (r *TaskRepository) CreateRepetitiveTaskTemplate(repetitiveTaskTemplate *models.RepetitiveTaskTemplate) error {


### PR DESCRIPTION
## Summary by Sourcery

Prevent users from updating tasks that do not belong to them by adding a check in the UpdateTask method to ensure the task belongs to the user before updating it.

Bug Fixes:
- Prevent users from updating tasks that do not belong to them.
- Return an unauthorized error when a user attempts to update a task that does not belong to them.
- Fixes an issue where the application did not verify ownership when updating tasks, allowing users to modify tasks created by others.