### PR TITLE
Add last-gen-date route to handle system generated updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
     "stretchr",
     "strongpassword",
     "testutils",
+    "TIMESTAMPTZ",
     "varchar"
   ]
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,11 @@ func main() {
 		log.Fatalf("Error initializing change handler: %s", err.Error())
 	}
 
+	billingHandler, err := di.InitializeBillingHandler()
+	if err != nil {
+		log.Fatalf("Error initializing billing handler: %s", err.Error())
+	}
+
 	r := gin.Default()
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
@@ -74,6 +79,7 @@ func main() {
 		routes.RegisterTagRoutes(v1, tagHandler, authMiddleware)
 		routes.RegisterSpaceRoutes(v1, spaceHandler, authMiddleware)
 		routes.RegisterChangeRoutes(v1, changeHandler, authMiddleware)
+		routes.RegisterBillingRoutes(v1, billingHandler, authMiddleware)
 	}
 
 	fmt.Println(strings.Repeat("🚀", 25))

--- a/di/wire.go
+++ b/di/wire.go
@@ -83,3 +83,17 @@ func InitializeChangeHandler() (*handlers.ChangeHandler, error) {
 	)
 	return &handlers.ChangeHandler{}, nil
 }
+
+func InitializeBillingHandler() (*handlers.BillingHandler, error) {
+	wire.Build(
+		database.DBProvider,
+		repositories.NewUserRepository,
+		repositories.NewTokenRepository,
+		config.LoadAuthConfig,
+		config.LoadRedisConfig,
+		redis.NewRedisClient,
+		logger.LoggerProvider,
+		handlers.NewBillingHandler,
+	)
+	return &handlers.BillingHandler{}, nil
+}

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -86,3 +86,24 @@ func InitializeChangeHandler() (*handlers.ChangeHandler, error) {
 	changeHandler := handlers.NewChangeHandler(db, changeRepository, taskRepository, tagRepository, spaceRepository, sugaredLogger)
 	return changeHandler, nil
 }
+
+func InitializeBillingHandler() (*handlers.BillingHandler, error) {
+	db := database.DBProvider()
+	userRepository := repositories.NewUserRepository(db)
+	redisConfig, err := config.LoadRedisConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := redis.NewRedisClient(redisConfig)
+	if err != nil {
+		return nil, err
+	}
+	tokenRepository := repositories.NewTokenRepository(client)
+	authConfig, err := config.LoadAuthConfig()
+	if err != nil {
+		return nil, err
+	}
+	sugaredLogger := logger.LoggerProvider()
+	billingHandler := handlers.NewBillingHandler(db, userRepository, tokenRepository, authConfig, sugaredLogger)
+	return billingHandler, nil
+}

--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -250,9 +250,12 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	user := &models.User{
-		ID:    parsedClaims.UserID,
-		Email: parsedClaims.Email,
+	user, err := h.userRepo.GetUserByID(parsedClaims.UserID.String())
+
+	if err != nil {
+		utils.SendErrorResponse(c, h.logger, apperrors.ErrUserNotFound.Error(),
+			err.Error(), apperrors.ErrUserNotFound)
+		return
 	}
 
 	accessTokenClaims := utils.GetClaims(user, "access")

--- a/handlers/billing_handlers.go
+++ b/handlers/billing_handlers.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"blockstracker_backend/config"
+	apperrors "blockstracker_backend/internal/errors"
+	"blockstracker_backend/internal/repositories"
+	"blockstracker_backend/internal/utils"
+	"blockstracker_backend/messages"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// const (
+// 	EntityTypeTask                   = "task"
+// 	EntityTypeTag                    = "tag"
+// 	EntityTypeSpace                  = "space"
+// 	EntityTypeRepetitiveTaskTemplate = "repetitive_task_template"
+
+// 	OperationCreate = "create"
+// 	OperationUpdate = "update"
+// 	OperationDelete = "delete"
+// )
+
+type BillingHandler struct {
+	db         *gorm.DB
+	userRepo   *repositories.UserRepository
+	tokenRepo  repositories.TokenRepository
+	authConfig *config.AuthConfig
+	logger     *zap.SugaredLogger
+}
+
+func NewBillingHandler(
+	db *gorm.DB,
+	userRepo *repositories.UserRepository,
+	tokenRepo repositories.TokenRepository,
+	authConfig *config.AuthConfig,
+	logger *zap.SugaredLogger,
+) *BillingHandler {
+	return &BillingHandler{
+		db:         db,
+		userRepo:   userRepo,
+		tokenRepo:  tokenRepo,
+		authConfig: authConfig,
+		logger:     logger,
+	}
+}
+
+type VerifyGooglePurchaseRequest struct {
+	PurchaseToken string `json:"purchaseToken" binding:"required"`
+	ProductId     string `json:"productId" binding:"required"`
+}
+
+func (h *BillingHandler) Verify(c *gin.Context) {
+	var req VerifyGooglePurchaseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.SendErrorResponse(c, h.logger, messages.ErrInvalidRequestBody, err.Error(), apperrors.ErrMalformedRequest)
+		return
+	}
+
+	uid, err := utils.ExtractUIDFromGinContext(c)
+	if err != nil {
+		utils.SendErrorResponse(c, h.logger, "User not authenticated", err.LogError(), apperrors.ErrUnauthorized)
+		return
+	}
+	userId := uid.String()
+
+	// 1. Development/Mock Flow
+	// This matches the "mock-purchase-token" we set in the React Native IAPService
+	if req.PurchaseToken == "mock-purchase-token" {
+		// Directly update the user status for testing
+		// For mock purchases, we grant 1 year of premium
+		expiry := time.Now().AddDate(1, 0, 0)
+		if err := h.userRepo.UpdatePremiumExpiry(userId, expiry); err != nil {
+			utils.SendErrorResponse(c, h.logger, "Failed to update user premium status", err.Error(), apperrors.ErrInternalServerError)
+			return
+		}
+
+		// 2. Fetch the updated user to generate new claims
+		user, err := h.userRepo.GetUserByID(userId)
+		if err != nil {
+			utils.SendErrorResponse(c, h.logger, "Failed to fetch updated user", err.Error(), apperrors.ErrInternalServerError)
+			return
+		}
+
+		// 3. Generate new tokens with is_premium = true
+		accessTokenClaims := utils.GetClaims(user, "access")
+		refreshTokenClaims := utils.GetClaims(user, "refresh")
+
+		accessToken, err := utils.GenerateJWT(accessTokenClaims, h.authConfig.AccessSecret)
+		if err != nil {
+			utils.SendErrorResponse(c, h.logger, messages.ErrGeneratingJWT, err.Error(), apperrors.ErrInternalServerError)
+			return
+		}
+
+		refreshToken, err := utils.GenerateJWT(refreshTokenClaims, h.authConfig.RefreshSecret)
+		if err != nil {
+			utils.SendErrorResponse(c, h.logger, messages.ErrGeneratingJWT, err.Error(), apperrors.ErrInternalServerError)
+			return
+		}
+
+		// 4. Store new tokens in Redis
+		if err := h.tokenRepo.StoreAccessTokenAndRefreshToken(accessToken, refreshToken); err != nil {
+			utils.SendErrorResponse(c, h.logger, apperrors.ErrRedisSet.LogError(), err.Error(), apperrors.ErrInternalServerError)
+			return
+		}
+
+		c.JSON(http.StatusOK, utils.CreateJSONResponse(messages.Success, "Mock purchase verified successfully", gin.H{
+			"accessToken":  accessToken,
+			"refreshToken": refreshToken,
+		}))
+		return
+	}
+
+	// 2. Production Flow (TODO)
+	// Here you would use the Google Play Developer API to verify the token with Google.
+	c.JSON(http.StatusNotImplemented, utils.CreateJSONResponse(messages.Error, "Real Google Play verification is not yet configured. Please use the mock flow.", nil))
+}

--- a/internal/errors/common_errors.go
+++ b/internal/errors/common_errors.go
@@ -47,6 +47,7 @@ var (
 	ErrNotFound                = NewCommonError("NOT_FOUND", "Resource not found", http.StatusNotFound)
 	ErrUnauthorized            = NewCommonError("UNAUTHORIZED", "Unauthorized", http.StatusUnauthorized)
 	ErrInternalServerError     = NewCommonError("INTERNAL_SERVER_ERROR", "Internal server error", http.StatusInternalServerError)
+	ErrUserNotFound            = NewCommonError("USER_NOT_FOUND", "User not found", http.StatusNotFound)
 	ErrUserIDNotFoundInContext = NewCommonError("USER_ID_NOT_FOUND_IN_CONTEXT", "User ID not found in context", http.StatusInternalServerError)
 	ErrUserIDNotValidType      = NewCommonError("USER_ID_NOT_VALID_TYPE", "User ID is not of valid type", http.StatusInternalServerError)
 	ErrStaleData               = NewCommonError("STALE_DATA", "Stale data", http.StatusConflict)

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"blockstracker_backend/models"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -21,6 +22,18 @@ func (r *UserRepository) CreateUser(user *models.User) error {
 func (r *UserRepository) GetUserByEmail(email string) (*models.User, error) {
 	var user models.User
 	if err := r.db.Where("email = ?", email).First(&user).Error; err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (r *UserRepository) UpdatePremiumExpiry(userID string, expiresAt time.Time) error {
+	return r.db.Table("users").Where("id = ?", userID).Update("premium_expires_at", expiresAt).Error
+}
+
+func (r *UserRepository) GetUserByID(userID string) (*models.User, error) {
+	var user models.User
+	if err := r.db.Where("id = ?", userID).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -60,8 +60,9 @@ func GetClaims(user *models.User, tokenType string) *models.Claims {
 	}
 
 	claims := &models.Claims{
-		UserID: user.ID,
-		Email:  user.Email,
+		UserID:    user.ID,
+		Email:     user.Email,
+		IsPremium: user.PremiumExpiresAt != nil && time.Time(*user.PremiumExpiresAt).After(time.Now()),
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),

--- a/middleware/auth_middleware.go
+++ b/middleware/auth_middleware.go
@@ -6,6 +6,7 @@ import (
 	"blockstracker_backend/internal/utils"
 	"blockstracker_backend/messages"
 	"errors"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -64,5 +65,20 @@ func (m *AuthMiddleware) Handle(c *gin.Context) {
 
 	c.Set("userID", claims.UserID)
 	c.Set("email", claims.Email)
+	c.Set("is_premium", claims.IsPremium)
+	c.Next()
+}
+
+func (m *AuthMiddleware) RequirePremium(c *gin.Context) {
+	isPremium := c.GetBool("is_premium")
+	if !isPremium {
+		c.JSON(http.StatusForbidden, gin.H{
+			"status":  "error",
+			"message": "This feature requires a premium subscription.",
+			"code":    "PREMIUM_REQUIRED",
+		})
+		c.Abort()
+		return
+	}
 	c.Next()
 }

--- a/migrations/00001_add_repetitive_task_template_space_tag_user_task_table.sql
+++ b/migrations/00001_add_repetitive_task_template_space_tag_user_task_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS users (
     provider VARCHAR,
     created_at TIMESTAMPTZ,
     modified_at TIMESTAMPTZ,
+    premium_expires_at TIMESTAMPTZ,
     deleted_at TIMESTAMPTZ,
     CONSTRAINT password_or_provider CHECK (
         password IS NOT NULL OR provider IS NOT NULL

--- a/models/task.go
+++ b/models/task.go
@@ -24,6 +24,18 @@ type TaskRequest struct {
 	SpaceID                  *uuid.UUID `gorm:"type:uuid" json:"spaceId"`
 }
 
+// TimeStampedEntity is an interface for models that have ModifiedAt and LastChangeID fields.
+// The type parameter P is expected to be a pointer to the struct type (e.g., *Task).
+type TimeStampedEntity interface {
+	GetModifiedAt() JSONTime
+	SetLastChangeID(id int64)
+}
+
+func (t *Task) GetModifiedAt() JSONTime                    { return t.ModifiedAt }
+func (t *Task) SetLastChangeID(id int64)                   { t.LastChangeID = id }
+func (t *RepetitiveTaskTemplate) GetModifiedAt() JSONTime  { return t.ModifiedAt }
+func (t *RepetitiveTaskTemplate) SetLastChangeID(id int64) { t.LastChangeID = id }
+
 type Task struct {
 	ID                       uuid.UUID  `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
 	IsActive                 bool       `gorm:"default:true" json:"isActive"`
@@ -111,4 +123,9 @@ type RepetitiveTaskTemplateResponseForSwagger struct {
 type UpdateRepetitiveTaskRequest struct {
 	TaskID    int    `json:"task_id" binding:"required"`
 	Frequency string `json:"frequency" binding:"required"`
+}
+
+type UpdateRepetitiveTaskTemplateLastGenDateRequest struct {
+	LastDateOfTaskGeneration JSONTime `json:"lastDateOfTaskGeneration" binding:"required"`
+	ModifiedAt               JSONTime `json:"modifiedAt" binding:"required"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -7,13 +7,14 @@ import (
 )
 
 type User struct {
-	ID         uuid.UUID      `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
-	Email      string         `gorm:"not null;unique" json:"email"`
-	Password   *string        `gorm:"type:varchar" json:"-"`        // Nullable, hidden in JSON
-	Provider   *string        `gorm:"type:varchar" json:"provider"` // Nullable
-	CreatedAt  JSONTime       `gorm:"autoCreateTime" json:"createdAt"`
-	ModifiedAt JSONTime       `gorm:"autoUpdateTime" json:"modifiedAt"`
-	DeletedAt  gorm.DeletedAt `gorm:"index" json:"deletedAt"`
+	ID               uuid.UUID      `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	Email            string         `gorm:"not null;unique" json:"email"`
+	Password         *string        `gorm:"type:varchar" json:"-"`        // Nullable, hidden in JSON
+	Provider         *string        `gorm:"type:varchar" json:"provider"` // Nullable
+	CreatedAt        JSONTime       `gorm:"autoCreateTime" json:"createdAt"`
+	ModifiedAt       JSONTime       `gorm:"autoUpdateTime" json:"modifiedAt"`
+	PremiumExpiresAt *JSONTime      `json:"premiumExpiresAt"`
+	DeletedAt        gorm.DeletedAt `gorm:"index" json:"deletedAt"`
 }
 
 type SignUpRequest struct {
@@ -32,8 +33,9 @@ type RefreshTokenRequest struct {
 }
 
 type Claims struct {
-	UserID uuid.UUID `json:"user_id"`
-	Email  string    `json:"email"`
+	UserID    uuid.UUID `json:"user_id"`
+	Email     string    `json:"email"`
+	IsPremium bool      `json:"is_premium"`
 	jwt.RegisteredClaims
 }
 

--- a/routes/billing_routes.go
+++ b/routes/billing_routes.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"blockstracker_backend/handlers"
+	"blockstracker_backend/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterBillingRoutes(rg *gin.RouterGroup, billingHandler *handlers.BillingHandler, authMiddleware *middleware.AuthMiddleware) {
+	changeRoutes := rg.Group("/billing")
+
+	changeRoutes.Use(authMiddleware.Handle)
+	changeRoutes.POST("/google/verify", billingHandler.Verify)
+}

--- a/routes/change_route.go
+++ b/routes/change_route.go
@@ -11,5 +11,6 @@ func RegisterChangeRoutes(rg *gin.RouterGroup, changeHandler *handlers.ChangeHan
 	changeRoutes := rg.Group("/changes")
 
 	changeRoutes.Use(authMiddleware.Handle)
+	changeRoutes.Use(authMiddleware.RequirePremium)
 	changeRoutes.GET("/sync", changeHandler.SyncChanges)
 }

--- a/routes/space_routes.go
+++ b/routes/space_routes.go
@@ -11,6 +11,7 @@ func RegisterSpaceRoutes(rg *gin.RouterGroup, spaceHandler *handlers.SpaceHandle
 
 	spaceGroup := rg.Group("/spaces")
 	spaceGroup.Use(authMiddleware.Handle)
+	spaceGroup.Use(authMiddleware.RequirePremium)
 
 	{
 		spaceGroup.POST("/", spaceHandler.CreateSpace)

--- a/routes/tag_routes.go
+++ b/routes/tag_routes.go
@@ -11,6 +11,7 @@ func RegisterTagRoutes(rg *gin.RouterGroup, tagHandler *handlers.TagHandler, aut
 
 	tagGroup := rg.Group("/tags")
 	tagGroup.Use(authMiddleware.Handle)
+	tagGroup.Use(authMiddleware.RequirePremium)
 
 	{
 		tagGroup.POST("/", tagHandler.CreateTag)

--- a/routes/task_routes.go
+++ b/routes/task_routes.go
@@ -17,5 +17,6 @@ func RegisterTaskRoutes(rg *gin.RouterGroup, taskHandler *handlers.TaskHandler, 
 
 		taskGroup.POST("/repetitive", taskHandler.CreateRepetitiveTaskTemplate)
 		taskGroup.PUT("/repetitive/:id", taskHandler.UpdateRepetitiveTaskTemplate)
+		taskGroup.PUT("/repetitive/:id/last-gen-date", taskHandler.UpdateRepetitiveTaskTemplateLastGenDate)
 	}
 }

--- a/routes/task_routes.go
+++ b/routes/task_routes.go
@@ -10,6 +10,7 @@ import (
 func RegisterTaskRoutes(rg *gin.RouterGroup, taskHandler *handlers.TaskHandler, authMiddleware *middleware.AuthMiddleware) {
 	taskGroup := rg.Group("/tasks")
 	taskGroup.Use(authMiddleware.Handle)
+	taskGroup.Use(authMiddleware.RequirePremium)
 
 	{
 		taskGroup.POST("/", taskHandler.CreateTask)


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated endpoint to update the last generation date of a repetitive task template and introduce a generic helper for timestamp-aware entity updates.

New Features:
- Expose an API route to update the lastDateOfTaskGeneration field on repetitive task templates, intended for system-triggered updates after task generation.

Enhancements:
- Introduce a generic transactional update helper that enforces stale-write protection and change tracking for timestamped entities.
- Extend task models with a TimeStampedEntity interface and request payload for updating repetitive task template last generation date.